### PR TITLE
DRY examples

### DIFF
--- a/cflib/bootloader/__init__.py
+++ b/cflib/bootloader/__init__.py
@@ -34,10 +34,10 @@ import time
 import zipfile
 
 from .boottypes import BootVersion
-from .boottypes import Target
+from .boottypes import Target  # noqa
 from .boottypes import TargetTypes
 from .cloader import Cloader
-from cflib.utils.callbacks import Caller
+from cflib.utils.callbacks import Caller  # noqa
 
 logger = logging.getLogger(__name__)
 

--- a/cflib/crazyflie/toccache.py
+++ b/cflib/crazyflie/toccache.py
@@ -33,8 +33,8 @@ import logging
 import os
 from glob import glob
 
-from .log import LogTocElement  # pylint: disable=W0611
-from .param import ParamTocElement  # pylint: disable=W0611
+from .log import LogTocElement  # noqa
+from .param import ParamTocElement  # noqa
 
 __author__ = 'Bitcraze AB'
 __all__ = ['TocCache']

--- a/examples/basiclog.py
+++ b/examples/basiclog.py
@@ -31,12 +31,9 @@ import logging
 import time
 from threading import Timer
 
-import cflib.crtp  # noqa
 from cflib.crazyflie import Crazyflie
 from cflib.crazyflie.log import LogConfig
-
-# Only output errors from the logging framework
-logging.basicConfig(level=logging.ERROR)
+from examples.util import get_first_crazyflie
 
 
 class LoggingExample:
@@ -122,23 +119,18 @@ class LoggingExample:
         self.is_connected = False
 
 
-if __name__ == '__main__':
-    # Initialize the low-level drivers (don't list the debug drivers)
-    cflib.crtp.init_drivers(enable_debug_driver=False)
-    # Scan for Crazyflies and use the first one found
-    print('Scanning interfaces for Crazyflies...')
-    available = cflib.crtp.scan_interfaces()
-    print('Crazyflies found:')
-    for i in available:
-        print(i[0])
+def main():
+    # Only output errors from the logging framework
+    logging.basicConfig(level=logging.ERROR)
 
-    if len(available) > 0:
-        le = LoggingExample(available[0][0])
-    else:
-        print('No Crazyflies found, cannot run example')
+    example = LoggingExample(get_first_crazyflie())
 
     # The Crazyflie lib doesn't contain anything to keep the application alive,
     # so this is where your application should do something. In our case we
     # are just waiting until we are disconnected.
-    while le.is_connected:
+    while example.is_connected:
         time.sleep(1)
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/examples/basicparam.py
+++ b/examples/basicparam.py
@@ -32,11 +32,8 @@ import logging
 import random
 import time
 
-import cflib.crtp
 from cflib.crazyflie import Crazyflie
-
-# Only output errors from the logging framework
-logging.basicConfig(level=logging.ERROR)
+from examples.util import get_first_crazyflie
 
 
 class ParamExample:
@@ -154,22 +151,18 @@ class ParamExample:
         self.is_connected = False
 
 
-if __name__ == '__main__':
-    # Initialize the low-level drivers (don't list the debug drivers)
-    cflib.crtp.init_drivers(enable_debug_driver=False)
-    # Scan for Crazyflies and use the first one found
-    print('Scanning interfaces for Crazyflies...')
-    available = cflib.crtp.scan_interfaces()
-    print('Crazyflies found:')
-    for i in available:
-        print(i[0])
+def main():
 
-    if len(available) > 0:
-        pe = ParamExample(available[0][0])
-        # The Crazyflie lib doesn't contain anything to keep the application
-        # alive, so this is where your application should do something. In our
-        # case we are just waiting until we are disconnected.
-        while pe.is_connected:
-            time.sleep(1)
-    else:
-        print('No Crazyflies found, cannot run example')
+    # Only output errors from the logging framework
+    logging.basicConfig(level=logging.ERROR)
+
+    example = ParamExample(get_first_crazyflie())
+    # The Crazyflie lib doesn't contain anything to keep the application
+    # alive, so this is where your application should do something. In our
+    # case we are just waiting until we are disconnected.
+    while example.is_connected:
+        time.sleep(1)
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/examples/ramp.py
+++ b/examples/ramp.py
@@ -31,10 +31,8 @@ import logging
 import time
 from threading import Thread
 
-import cflib
 from cflib.crazyflie import Crazyflie
-
-logging.basicConfig(level=logging.ERROR)
+from examples.util import get_first_crazyflie
 
 
 class MotorRampExample:
@@ -101,17 +99,13 @@ class MotorRampExample:
         self._cf.close_link()
 
 
-if __name__ == '__main__':
-    # Initialize the low-level drivers (don't list the debug drivers)
-    cflib.crtp.init_drivers(enable_debug_driver=False)
-    # Scan for Crazyflies and use the first one found
-    print('Scanning interfaces for Crazyflies...')
-    available = cflib.crtp.scan_interfaces()
-    print('Crazyflies found:')
-    for i in available:
-        print(i[0])
+def main():
 
-    if len(available) > 0:
-        le = MotorRampExample(available[0][0])
-    else:
-        print('No Crazyflies found, cannot run example')
+    # Only output errors from the logging framework
+    logging.basicConfig(level=logging.ERROR)
+
+    MotorRampExample(get_first_crazyflie())
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/examples/read-ow.py
+++ b/examples/read-ow.py
@@ -31,12 +31,9 @@ import logging
 import sys
 import time
 
-import cflib.crtp  # noqa
 from cflib.crazyflie import Crazyflie
 from cflib.crazyflie.mem import MemoryElement
-
-# Only output errors from the logging framework
-logging.basicConfig(level=logging.ERROR)
+from examples.util import get_first_crazyflie
 
 
 class OWExample:
@@ -120,26 +117,22 @@ class OWExample:
         self.is_connected = False
 
 
-if __name__ == '__main__':
-    # Initialize the low-level drivers (don't list the debug drivers)
-    cflib.crtp.init_drivers(enable_debug_driver=False)
-    # Scan for Crazyflies and use the first one found
-    print('Scanning interfaces for Crazyflies...')
-    available = cflib.crtp.scan_interfaces()
-    print('Crazyflies found:')
-    for i in available:
-        print(i[0])
+def main():
 
-    if len(available) > 0:
-        le = OWExample(available[0][0])
-    else:
-        print('No Crazyflies found, cannot run example')
+    # Only output errors from the logging framework
+    logging.basicConfig(level=logging.ERROR)
+
+    example = OWExample(get_first_crazyflie())
 
     # The Crazyflie lib doesn't contain anything to keep the application alive,
     # so this is where your application should do something. In our case we
     # are just waiting until we are disconnected.
     try:
-        while le.is_connected:
+        while example.is_connected:
             time.sleep(1)
     except KeyboardInterrupt:
         sys.exit(1)
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/examples/scan.py
+++ b/examples/scan.py
@@ -26,13 +26,6 @@
 """
 Simple example that scans for available Crazyflies and lists them.
 """
-import cflib.crtp
+from examples.util import get_available_crazyflies
 
-# Initiate the low level drivers
-cflib.crtp.init_drivers(enable_debug_driver=False)
-
-print('Scanning interfaces for Crazyflies...')
-available = cflib.crtp.scan_interfaces()
-print('Crazyflies found:')
-for i in available:
-    print(i[0])
+get_available_crazyflies()

--- a/examples/util.py
+++ b/examples/util.py
@@ -1,0 +1,26 @@
+import sys
+
+from cflib import crtp
+
+
+def get_available_crazyflies():
+    # Initialize the low-level drivers (don't list the debug drivers)
+    crtp.init_drivers(enable_debug_driver=False)
+
+    print('Scanning for Crazyflies...')
+    available = crtp.scan_interfaces()
+
+    if not available:
+        sys.exit(
+            'No Crazyflies found, cannot run example. Have you turned it on?'
+        )
+
+    print('Crazyflies found:')
+    for crazyflie in available:
+        print(crazyflie[0])
+
+    return available
+
+
+def get_first_crazyflie():
+    return get_available_crazyflies()[0][0]

--- a/examples/write-eeprom.py
+++ b/examples/write-eeprom.py
@@ -31,12 +31,9 @@ import logging
 import sys
 import time
 
-import cflib.crtp
 from cflib.crazyflie import Crazyflie
 from cflib.crazyflie.mem import MemoryElement
-
-# Only output errors from the logging framework
-logging.basicConfig(level=logging.ERROR)
+from examples.util import get_first_crazyflie
 
 
 class EEPROMExample:
@@ -71,7 +68,7 @@ class EEPROMExample:
         print('Connected to %s' % link_uri)
 
         mems = self._cf.mem.get_mems(MemoryElement.TYPE_I2C)
-        print('Found {} EEPOM(s)'.format(len(mems)))
+        print('Found {} EEPROM(s)'.format(len(mems)))
         if len(mems) > 0:
             print('Writing default configuration to'
                   ' memory {}'.format(mems[0].id))
@@ -126,26 +123,22 @@ class EEPROMExample:
         self.is_connected = False
 
 
-if __name__ == '__main__':
-    # Initialize the low-level drivers (don't list the debug drivers)
-    cflib.crtp.init_drivers(enable_debug_driver=True)
-    # Scan for Crazyflies and use the first one found
-    print('Scanning interfaces for Crazyflies...')
-    available = cflib.crtp.scan_interfaces()
-    print('Crazyflies found:')
-    for i in available:
-        print(i[0])
+def main():
 
-    if len(available) > 0:
-        le = EEPROMExample(available[0][0])
-    else:
-        print('No Crazyflies found, cannot run example')
+    # Only output errors from the logging framework
+    logging.basicConfig(level=logging.ERROR)
+
+    example = EEPROMExample(get_first_crazyflie())
 
     # The Crazyflie lib doesn't contain anything to keep the application alive,
     # so this is where your application should do something. In our case we
     # are just waiting until we are disconnected.
     try:
-        while le.is_connected:
+        while example.is_connected:
             time.sleep(1)
     except KeyboardInterrupt:
         sys.exit(1)
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/examples/write-ow.py
+++ b/examples/write-ow.py
@@ -31,13 +31,10 @@ import logging
 import sys
 import time
 
-import cflib.crtp
 from cflib.crazyflie import Crazyflie
 from cflib.crazyflie.mem import MemoryElement
 from cflib.crazyflie.mem import OWElement
-
-# Only output errors from the logging framework
-logging.basicConfig(level=logging.ERROR)
+from examples.util import get_first_crazyflie
 
 
 class EEPROMExample:
@@ -132,29 +129,25 @@ class EEPROMExample:
         self.is_connected = False
 
 
-if __name__ == '__main__':
+def main():
+    # Only output errors from the logging framework
+    logging.basicConfig(level=logging.ERROR)
+
     print('This example will not work with the BLE version of the nRF51'
           ' firmware (flashed on production units). See https://github.com'
           '/bitcraze/crazyflie-clients-python/issues/166')
-    # Initialize the low-level drivers (don't list the debug drivers)
-    cflib.crtp.init_drivers(enable_debug_driver=True)
-    # Scan for Crazyflies and use the first one found
-    print('Scanning interfaces for Crazyflies...')
-    available = cflib.crtp.scan_interfaces()
-    print('Crazyflies found:')
-    for i in available:
-        print(i[0])
 
-    if len(available) > 0:
-        le = EEPROMExample(available[0][0])
-    else:
-        print('No Crazyflies found, cannot run example')
+    example = EEPROMExample(get_first_crazyflie())
 
     # The Crazyflie lib doesn't contain anything to keep the application alive,
     # so this is where your application should do something. In our case we
     # are just waiting until we are disconnected.
     try:
-        while le.is_connected:
+        while example.is_connected:
             time.sleep(1)
     except KeyboardInterrupt:
         sys.exit(1)
+
+
+if __name__ == '__main__':
+    exit(main())


### PR DESCRIPTION
Tested what I could locally with a Crazyflie v1 using `python -m`, also closes #1.