### PR TITLE
Add precommit to project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: 616c1ebd1898c91de9a0548866a59cbd9f4547f6
+    hooks:
+    -   id: autopep8-wrapper
+    -   id: check-added-large-files
+    -   id: check-case-conflict
+    -   id: check-docstring-first
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-xml
+    -   id: check-yaml
+    -   id: debug-statements
+    -   id: detect-private-key
+    -   id: double-quote-string-fixer
+    -   id: end-of-file-fixer
+    -   id: flake8
+    -   id: requirements-txt-fixer
+-   repo: git://github.com/asottile/reorder_python_imports
+    sha: f3dfe379d2ea341c6cf54d926d4585b35dea9251
+    hooks:
+    -   id: reorder-python-imports

--- a/README.md
+++ b/README.md
@@ -82,3 +82,9 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE="0664"
 ```
 
 [cfclient]: https://www.github.com/bitcraze/crazyflie-clients-python
+
+
+Contribute
+----------
+
+Everyone is encouraged to contribute to the CrazyFlie library by forking the Github repository and making a pull request or opening an issue.


### PR DESCRIPTION
To see this in action:
1. ``virtualenv venv``
2. ``source venv/bin/activate``
3. ``pip install precommit``
4. ``pre-commit run --all-files``

Typically you will not type ``pre-commit run --all-files.``  Instead you will run ``pre-commit install`` and it will run automatically on any code in which you do ``git commit``.  More information [here](http://pre-commit.com/)

This is a great example where having a Makefile that automates creation of the virtualenv and ensures that hooks are installed is very nice to have.  I was going to add it to the Readme in the contribution section, but that is up to you.