### PR TITLE
Fully integrated MotionCommander with SyncCrazyflie and SyncLogger

### DIFF
--- a/cflib/positioning/motion_commander.py
+++ b/cflib/positioning/motion_commander.py
@@ -61,7 +61,7 @@ class MotionCommander(SyncCrazyflie):
     RATE = 360.0 / 5
 
     def __init__(self, link_uri, cf=None, default_height=0.3,
-                 log_file='crazyflie_data.csv', log_vars=None, period_in_ms=10):
+                 log_file='crazyflie_data.csv', log_vars=[], period_in_ms=10):
         """
         Construct an instance of a MotionCommander
 

--- a/cflib/positioning/motion_commander.py
+++ b/cflib/positioning/motion_commander.py
@@ -49,7 +49,11 @@ from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
 from cflib.crazyflie.log import LogConfig
 from cflib.crazyflie.syncLogger import SyncLogger
 
-from queue import Queue, Empty, LifoQueue
+if sys.version_info < (3,):
+    from Queue import Queue, Empty, LifoQueue
+else:
+    from queue import Queue, Empty, LifoQueue
+
 
 class MotionCommander(SyncCrazyflie):
     """The motion commander"""
@@ -71,9 +75,9 @@ class MotionCommander(SyncCrazyflie):
         self._is_flying = False
         self._motion_thread = None
         self._logging_thread = _LoggingThread(log_file=log_file,
-                                      scf=self,
-                                      log_vars=log_vars, 
-                                        period_in_ms=period_in_ms)
+                                              scf=self,
+                                              log_vars=log_vars,
+                                              period_in_ms=period_in_ms)
     # Distance based primitives
 
     def take_off(self, height=None, velocity=VELOCITY):
@@ -488,6 +492,7 @@ class _SetPointThread(Thread):
         now = time.time()
         return self._z_base + self._z_velocity * (now - self._z_base_time)
 
+
 class _LoggingThread(Thread):
 
     def __init__(self, log_file, scf, log_vars, period_in_ms=10):
@@ -502,7 +507,7 @@ class _LoggingThread(Thread):
         self.terminate = False
 
     def run(self):
-    """
+        """
         Places log variables in queue and prints them to file until terminated
 
         :return:
@@ -510,7 +515,7 @@ class _LoggingThread(Thread):
         self.sync_logger.connect()
         for log_entry in self.sync_logger:
             if self.terminate == True:
-               return
+                return
             current_log_values = log_entry[1]
             self.queue.put(current_log_values)
             self.log_fp.write(str(current_log_values) + '\n')
@@ -525,4 +530,3 @@ class _LoggingThread(Thread):
         self.join()
         self.sync_logger.disconnect()
         self.log_fp.close()
-

--- a/cflib/positioning/motion_commander.py
+++ b/cflib/positioning/motion_commander.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-#
 #     ||          ____  _ __
 #  +------+      / __ )(_) /_______________ _____  ___
 #  | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
@@ -37,6 +36,9 @@ appropriate by issuing new commands.
 The MotionCommander can be used as context manager using the with keyword. In
 this mode of operation takeoff and landing is executed when the context is
 created/closed.
+
+The MotionCommander can also log pre-defined variables as they become
+available, and print them to a file for later processing. 
 """
 import math
 import sys
@@ -44,35 +46,34 @@ import time
 from threading import Thread
 
 from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
+from cflib.crazyflie.log import LogConfig
+from cflib.crazyflie.syncLogger import SyncLogger
 
-if sys.version_info < (3,):
-    from Queue import Queue, Empty
-else:
-    from queue import Queue, Empty
+from queue import Queue, Empty, LifoQueue
 
-
-class MotionCommander:
+class MotionCommander(SyncCrazyflie):
     """The motion commander"""
     VELOCITY = 0.2
     RATE = 360.0 / 5
 
-    def __init__(self, crazyflie, default_height=0.3):
+    def __init__(self, link_uri, cf=None, default_height=0.3,
+                 log_file='crazyflie_data.csv', log_vars=None, period_in_ms=10):
         """
         Construct an instance of a MotionCommander
 
         :param crazyflie: a Crazyflie or SyncCrazyflie instance
         :param default_height: the default height to fly at
         """
-        if isinstance(crazyflie, SyncCrazyflie):
-            self._cf = crazyflie.cf
-        else:
-            self._cf = crazyflie
+        SyncCrazyflie.__init__(self, link_uri, cf)
 
         self.default_height = default_height
 
         self._is_flying = False
-        self._thread = None
-
+        self._motion_thread = None
+        self._logging_thread = _LoggingThread(log_file=log_file,
+                                      scf=self,
+                                      log_vars=log_vars, 
+                                        period_in_ms=period_in_ms)
     # Distance based primitives
 
     def take_off(self, height=None, velocity=VELOCITY):
@@ -89,14 +90,14 @@ class MotionCommander:
         if self._is_flying:
             raise Exception('Already flying')
 
-        if not self._cf.is_connected():
+        if not self.cf.is_connected():
             raise Exception('Crazyflie is not connected')
 
         self._is_flying = True
         self._reset_position_estimator()
 
-        self._thread = _SetPointThread(self._cf)
-        self._thread.start()
+        self._motion_thread = _SetPointThread(self.cf)
+        self._motion_thread.start()
 
         if height is None:
             height = self.default_height
@@ -114,20 +115,27 @@ class MotionCommander:
         :return:
         """
         if self._is_flying:
-            self.down(self._thread.get_height(), velocity)
+            self.down(self._motion_thread.get_height(), velocity)
 
-            self._thread.stop()
-            self._thread = None
+            self._motion_thread.stop()
+            self._motion_thread = None
 
-            self._cf.commander.send_stop_setpoint()
+            self.cf.commander.send_stop_setpoint()
             self._is_flying = False
 
     def __enter__(self):
+        super().__enter__()
+        self._logging_thread.start()
         self.take_off()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.land()
+        self._logging_thread.stop()
+        super().__exit__(exc_type, exc_val, exc_tb)
+
+    def __getitem__(self, key):
+        return self._logging_thread.queue.get()[key]
 
     def left(self, distance_m, velocity=VELOCITY):
         """
@@ -403,13 +411,13 @@ class MotionCommander:
     def _set_vel_setpoint(self, velocity_x, velocity_y, velocity_z, rate_yaw):
         if not self._is_flying:
             raise Exception('Can not move on the ground. Take off first!')
-        self._thread.set_vel_setpoint(
+        self._motion_thread.set_vel_setpoint(
             velocity_x, velocity_y, velocity_z, rate_yaw)
 
     def _reset_position_estimator(self):
-        self._cf.param.set_value('kalman.resetEstimation', '1')
+        self.cf.param.set_value('kalman.resetEstimation', '1')
         time.sleep(0.1)
-        self._cf.param.set_value('kalman.resetEstimation', '0')
+        self.cf.param.set_value('kalman.resetEstimation', '0')
         time.sleep(2)
 
 
@@ -423,7 +431,7 @@ class _SetPointThread(Thread):
         self.update_period = update_period
 
         self._queue = Queue()
-        self._cf = cf
+        self.cf = cf
 
         self._hover_setpoint = [0.0, 0.0, 0.0, 0.0]
 
@@ -464,7 +472,7 @@ class _SetPointThread(Thread):
                 pass
 
             self._update_z_in_setpoint()
-            self._cf.commander.send_hover_setpoint(*self._hover_setpoint)
+            self.cf.commander.send_hover_setpoint(*self._hover_setpoint)
 
     def _new_setpoint(self, velocity_x, velocity_y, velocity_z, rate_yaw):
         self._z_base = self._current_z()
@@ -479,3 +487,42 @@ class _SetPointThread(Thread):
     def _current_z(self):
         now = time.time()
         return self._z_base + self._z_velocity * (now - self._z_base_time)
+
+class _LoggingThread(Thread):
+
+    def __init__(self, log_file, scf, log_vars, period_in_ms=10):
+        Thread.__init__(self)
+        self.log_config = LogConfig('GenericLogConfig', period_in_ms)
+        for var in log_vars:
+            self.log_config.add_variable(var)
+        self.queue = LifoQueue()
+        self.log_fp = open(log_file, 'w+')
+        self.scf = scf
+        self.sync_logger = SyncLogger(self.scf, self.log_config)
+        self.terminate = False
+
+    def run(self):
+    """
+        Places log variables in queue and prints them to file until terminated
+
+        :return:
+        """
+        self.sync_logger.connect()
+        for log_entry in self.sync_logger:
+            if self.terminate == True:
+               return
+            current_log_values = log_entry[1]
+            self.queue.put(current_log_values)
+            self.log_fp.write(str(current_log_values) + '\n')
+
+    def stop(self):
+        """
+        Stop the thread and wait for it to terminate
+
+        :return:
+        """
+        self.terminate = True
+        self.join()
+        self.sync_logger.disconnect()
+        self.log_fp.close()
+

--- a/examples/motion_commander_demo.py
+++ b/examples/motion_commander_demo.py
@@ -56,61 +56,61 @@ if __name__ == '__main__':
 
     with MotionCommander(URI, log_file=log_file, log_vars=log_vars) as mc:
         # We take off when the commander is created
-            time.sleep(1)
+        time.sleep(1)
 
-            # There is a set of functions that move a specific distance
-            # We can move in all directions
-            mc.forward(0.8)
-            mc.back(0.8)
-            time.sleep(1)
+        # There is a set of functions that move a specific distance
+        # We can move in all directions
+        mc.forward(0.8)
+        mc.back(0.8)
+        time.sleep(1)
 
-            mc.up(0.5)
-            mc.down(0.5)
-            time.sleep(1)
+        mc.up(0.5)
+        mc.down(0.5)
+        time.sleep(1)
 
-            # We can also set the velocity
-            mc.right(0.5, velocity=0.8)
-            time.sleep(1)
-            mc.left(0.5, velocity=0.4)
-            time.sleep(1)
+        # We can also set the velocity
+        mc.right(0.5, velocity=0.8)
+        time.sleep(1)
+        mc.left(0.5, velocity=0.4)
+        time.sleep(1)
 
-            # We can do circles or parts of circles
-            mc.circle_right(0.5, velocity=0.5, angle_degrees=180)
+        # We can do circles or parts of circles
+        mc.circle_right(0.5, velocity=0.5, angle_degrees=180)
 
-            # Or turn
-            mc.turn_left(90)
-            time.sleep(1)
+        # Or turn
+        mc.turn_left(90)
+        time.sleep(1)
 
-            # We can move along a line in 3D space
-            mc.move_distance(-1, 0.0, 0.5, velocity=0.6)
-            time.sleep(1)
+        # We can move along a line in 3D space
+        mc.move_distance(-1, 0.0, 0.5, velocity=0.6)
+        time.sleep(1)
 
-            # There is also a set of functions that start a motion. The
-            # Crazyflie will keep on going until it gets a new command.
+        # There is also a set of functions that start a motion. The
+        # Crazyflie will keep on going until it gets a new command.
 
-            mc.start_left(velocity=0.5)
-            # The motion is started and we can do other stuff, printing for
-            # instance
-            for _ in range(5):
-                print('Doing other work')
-                time.sleep(0.2)
+        mc.start_left(velocity=0.5)
+        # The motion is started and we can do other stuff, printing for
+        # instance
+        for _ in range(5):
+            print('Doing other work')
+            time.sleep(0.2)
 
-            # And we can stop
-            mc.stop()
+        # And we can stop
+        mc.stop()
 
-            # We can determine how much the crazyflie drifts in a specific
-            # direction over the span of one second
-            max_drift = mc['kalman.stateX']
-            min_drift = max_drift
-            for _ in range(100):
-                x = mc['kalman.stateX']
-                if x > max_drift:
-                    max_drift = x
-                elif x < min_drift:
-                    min_drift = x
-                time.sleep(0.01)
-            print('The crazyflie drifted over: ' 
-                  + str(max_drift - min_drift)
-                  + ' meters in the x direction')
+        # We can determine how much the crazyflie drifts in a specific
+        # direction over the span of one second
+        max_drift = mc['kalman.stateX']
+        min_drift = max_drift
+        for _ in range(100):
+            x = mc['kalman.stateX']
+            if x > max_drift:
+                max_drift = x
+            elif x < min_drift:
+                min_drift = x
+            time.sleep(0.01)
+        print('The crazyflie drifted over: '
+              + str(max_drift - min_drift)
+              + ' meters in the x direction')
 
-            # We land when the MotionCommander goes out of scope
+        # We land when the MotionCommander goes out of scope

--- a/examples/motion_commander_demo.py
+++ b/examples/motion_commander_demo.py
@@ -41,7 +41,8 @@ from cflib.crazyflie import Crazyflie
 from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
 from cflib.positioning.motion_commander import MotionCommander
 
-URI = 'radio://0/80/250K'
+URI = 'radio://0/70/2M'
+#URI = 'radio://0/80/250K'
 
 # Only output errors from the logging framework
 logging.basicConfig(level=logging.ERROR)


### PR DESCRIPTION
Up until now, if a user wanted to use the motion commander library and log variables, they would need to use 3 separate with blocks, which is rather unpythonic. I changed MotionCommander so that it inherits SyncCrazyflie, rather than requiring SyncCrazyflie as an argument. Additionally, I added the ability to spawn a thread that automatically prints logging variables to a user-designated file, and allows access to those variables mid-flight. 