### PR TITLE
Continue to support V1 protocols.

### DIFF
--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -172,7 +172,7 @@ class Param():
             if self._useV2:
                 s = struct.unpack(element.pytype, pk.data[2:])[0]
             else:
-                s = struct.unpack(element.pytype, pk.data[2:])[0]
+                s = struct.unpack(element.pytype, pk.data[1:])[0]
             s = s.__str__()
             complete_name = '%s.%s' % (element.group, element.name)
 

--- a/cflib/crazyflie/toc.py
+++ b/cflib/crazyflie/toc.py
@@ -189,7 +189,10 @@ class TocFetcher:
 
             if ident != self.requested_index:
                 return
-            self.toc.add_element(self.element_class(ident, payload[2:]))
+            if self._useV2:
+                self.toc.add_element(self.element_class(ident, payload[2:]))
+            else:
+                self.toc.add_element(self.element_class(ident, payload[1:]))
             logger.debug('Added element [%s]', ident)
             if (self.requested_index < (self.nbr_of_items - 1)):
                 logger.debug('[%d]: More variables, requesting index %d',


### PR DESCRIPTION
A couple of cases were missed in updates for #89, such that comms fail if the crazyflie is still running protocol v1 (not sure if that’s the right name? anyway, the previous protocol).
 
  * cflib/crazyflie/param.py (Param._param_updated): if not using
      protocol v2, only strip one byte before unpacking the data.
  * cflib/crazyflie/toc.py (TocFetcher._new_packet_cb): likewise, for
      GET_TOC_ELEMENT.