### PR TITLE
docs: addition to Testing section about python3.6 on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ work needed to maintain your python environmet.
 
 ### Native python on Linux, OSX, Windows
 * [Tox](http://tox.readthedocs.org/en/latest/) is used for native testing: `pip install tox`
+* on Linux for python3.6 if test fails after installing tox with `pip install tox`, installing with  `sudo apt-get install tox`result a successful test run
+
 * Test package in python2.7 `TOXENV=py27 tox`
 * Test package in python3.4 `TOXENV=py34 tox`
+* Test package in python3.6 `TOXENV=py36 tox`
 
 Note: You must have the specific python versions on your machine or tests will fail. (ie. without specifying the TOXENV, `tox` runs tests for python2.7, 3.3, 3.4 and would require all python versions to be installed on the machine.)
 

--- a/src/pip-delete-this-directory.txt
+++ b/src/pip-delete-this-directory.txt
@@ -1,5 +1,0 @@
-This file is placed here by pip to indicate the source was put
-here by pip.
-
-Once this package is successfully installed this source code will be
-deleted (unless you remove this file).

--- a/src/pip-delete-this-directory.txt
+++ b/src/pip-delete-this-directory.txt
@@ -1,0 +1,5 @@
+This file is placed here by pip to indicate the source was put
+here by pip.
+
+Once this package is successfully installed this source code will be
+deleted (unless you remove this file).


### PR DESCRIPTION
I tried to install tox with `pip install tox` my testings failed but
`sudo apt-get install tox` worked and using the command `TOXENV=py36 tox`
my text passed. Thus, I am **proposing** add those line below to the
 README.md file

* on Linux for python3.6 if the test fails after installing tox with
 `pip install tox`, installing with  `sudo apt-get install tox` result
 a successful test run

* Test package in python3.6 `TOXENV=py36 tox`