### PR TITLE
Append the device only if the manufacturer name is 'Bitcraze AB'

### DIFF
--- a/cflib/drivers/cfusb.py
+++ b/cflib/drivers/cfusb.py
@@ -65,7 +65,8 @@ def _find_devices():
     if pyusb1:
         for d in usb.core.find(idVendor=USB_VID, idProduct=USB_PID, find_all=1,
                                backend=pyusb_backend):
-            ret.append(d)
+            if d.manufacturer == 'Bitcraze AB':
+                ret.append(d)
     else:
         busses = usb.busses()
         for bus in busses:


### PR DESCRIPTION
When devices with the same VendorID and ProductID as the
roadrunner/crazyflie are connected at the same time, the cflib fails to connect to
the device. A quick fix for this is done by checking if the
manufacturer name is 'Bitcraze AB'