### PR TITLE
Increase write flash request timeout to 2.5s, fixes #98

### DIFF
--- a/cflib/bootloader/cloader.py
+++ b/cflib/bootloader/cloader.py
@@ -381,7 +381,14 @@ class Cloader:
             pk.data = struct.pack('<BBHHH', addr, 0x18, page_buffer,
                                   target_page, page_count)
             self.link.send_packet(pk)
-            pk = self.link.receive_packet(1)
+
+            # Timeout for writing to flash is raised from 1s (used elsewhere
+            # in this module) to 2.5s because it may take more than a second
+            # to erase a page on the STM32F405.
+            #
+            # See https://github.com/bitcraze/crazyflie-lib-python/issues/98
+            # for more details.
+            pk = self.link.receive_packet(2.5)
             retry_counter -= 1
 
         if retry_counter < 0:


### PR DESCRIPTION
As discussed in #98, this PR raises the timeout for "write flash" requests to 2.5 seconds unconditionally to cater for the increased time needed to erase a page of 128K on an STM32F405.

Note that the timeout is applied unconditionally, even if we are flashing to the nRF51. In my opinion this is not a big deal because the flash packets go through just fine almost all the time, so there is almost never any need for re-sending them. However, re-sending them too early when the packet in fact went through can break the flashing process, as indicated by #98.