### PR TITLE
Fix documentaion and some code typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For information and installation of the
 * Check to see if you pass style guidelines: `tb verify`
 
 Note: Docker and the toolbelt is an optional way of running tests and reduces the 
-work needed to maintain your python environmet. 
+work needed to maintain your python environment.
 
 ### Native python on Linux, OSX, Windows
  [Tox](http://tox.readthedocs.org/en/latest/) is used for native testing: `pip install tox`

--- a/cflib/crazyflie/high_level_commander.py
+++ b/cflib/crazyflie/high_level_commander.py
@@ -75,7 +75,7 @@ class HighLevelCommander():
         """
         vertical takeoff from current x-y position to given height
 
-        :param absolute_height_m: absolut (m)
+        :param absolute_height_m: absolute (m)
         :param duration_s: time it should take until target height is
                            reached (s)
         :param group_mask: mask for which CFs this should apply to
@@ -100,7 +100,7 @@ class HighLevelCommander():
         """
         vertical land from current x-y position to given height
 
-        :param absolute_height_m: absolut (m)
+        :param absolute_height_m: absolute (m)
         :param duration_s: time it should take until target height is
                            reached (s)
         :param group_mask: mask for which CFs this should apply to

--- a/cflib/crazyflie/platformservice.py
+++ b/cflib/crazyflie/platformservice.py
@@ -117,7 +117,7 @@ class PlatformService():
                 self._cf.send_packet(pk)
             else:
                 self._protocolVersion = -1
-                logger.info('Procotol version: {}'.format(
+                logger.info('Protocol version: {}'.format(
                     self.get_protocol_version()))
                 self._callback()
 
@@ -125,6 +125,6 @@ class PlatformService():
         if pk.channel == VERSION_COMMAND and \
                 pk.data[0] == VERSION_GET_PROTOCOL:
             self._protocolVersion = pk.data[1]
-            logger.info('Procotol version: {}'.format(
+            logger.info('Protocol  version: {}'.format(
                 self.get_protocol_version()))
             self._callback()

--- a/cflib/crazyflie/syncCrazyflie.py
+++ b/cflib/crazyflie/syncCrazyflie.py
@@ -24,7 +24,7 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA  02110-1301, USA.
 """
-The syncronous Crazyflie class is a wrapper around the "normal" Crazyflie
+The synchronous Crazyflie class is a wrapper around the "normal" Crazyflie
 class. It handles the asynchronous nature of the Crazyflie API and turns it
 into blocking function. It is useful for simple scripts that performs tasks
 as a sequence of events.

--- a/cflib/crazyflie/toc.py
+++ b/cflib/crazyflie/toc.py
@@ -25,7 +25,7 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA  02110-1301, USA.
 """
-A generic TableOfContents module that is used to fetch, store and minipulate
+A generic TableOfContents module that is used to fetch, store and manipulate
 a TOC for logging or parameters.
 """
 import logging

--- a/cflib/crtp/serialdriver.py
+++ b/cflib/crtp/serialdriver.py
@@ -217,7 +217,7 @@ class _SerialReceiveThread(threading.Thread):
                 if r != expected:
                     continue
 
-                # NOTE: end is (expected - 2) as the lenght of the data +2 for
+                # NOTE: end is (expected - 2) as the length of the data +2 for
                 # the header bytes
                 cksum = compute_cksum(memoryview(received)[:expected])
                 if cksum[0] != received_data_chk[-2] or \

--- a/cflib/crtp/usbdriver.py
+++ b/cflib/crtp/usbdriver.py
@@ -71,7 +71,7 @@ class UsbDriver(CRTPDriver):
 
         The callback for linkQuality can be called at any moment from the
         driver to report back the link quality in percentage. The
-        callback from linkError will be called when a error occues with
+        callback from linkError will be called when a error occurs with
         an error message.
         """
 
@@ -215,7 +215,7 @@ class _UsbReceiveThread(threading.Thread):
     Radio link receiver thread used to read data from the
     Crazyradio USB driver. """
 
-    # RETRYCOUNT_BEFORE_DISCONNECT = 10
+    # RETRY_COUNT_BEFORE_DISCONNECT = 10
 
     def __init__(self, cfusb, inQueue, link_quality_callback,
                  link_error_callback):

--- a/cflib/drivers/cfusb.py
+++ b/cflib/drivers/cfusb.py
@@ -143,7 +143,7 @@ class CfUsb:
     # Data transfers
     def send_packet(self, dataOut):
         """ Send a packet and receive the ack from the radio dongle
-            The ack contains information about the packet transmition
+            The ack contains information about the packet transmission
             and a data payload if the ack packet contained any """
         try:
             if (pyusb1 is False):

--- a/cflib/drivers/crazyradio.py
+++ b/cflib/drivers/crazyradio.py
@@ -278,10 +278,10 @@ class Crazyradio:
                     result = result + (i,)
             return result
 
-    # Data transferts
+    # Data transfers
     def send_packet(self, dataOut):
         """ Send a packet and receive the ack from the radio dongle
-            The ack contains information about the packet transmition
+            The ack contains information about the packet transmission
             and a data payload if the ack packet contained any """
         ackIn = None
         data = None

--- a/cflib/positioning/motion_commander.py
+++ b/cflib/positioning/motion_commander.py
@@ -80,7 +80,7 @@ class MotionCommander:
 
     def take_off(self, height=None, velocity=VELOCITY):
         """
-        Takes off, that is starts the motors, goes straigt up and hovers.
+        Takes off, that is starts the motors, goes straight up and hovers.
         Do not call this function if you use the with keyword. Take off is
         done automatically when the context is created.
 
@@ -197,7 +197,7 @@ class MotionCommander:
         Turn to the left, staying on the spot
 
         :param angle_degrees: How far to turn (degrees)
-        :param rate: The trurning speed (degrees/second)
+        :param rate: The turning speed (degrees/second)
         :return:
         """
         flight_time = angle_degrees / rate
@@ -211,7 +211,7 @@ class MotionCommander:
         Turn to the right, staying on the spot
 
         :param angle_degrees: How far to turn (degrees)
-        :param rate: The trurning speed (degrees/second)
+        :param rate: The turning speed (degrees/second)
         :return:
         """
         flight_time = angle_degrees / rate

--- a/docs/development/matlab.md
+++ b/docs/development/matlab.md
@@ -39,7 +39,7 @@ double dashes (no space) before 'build-base' and 'user'.
 
 ### More information (from Mathworks MATLAB documentation)
 
-System reqirements:
+System requirements:
 <http://www.mathworks.com/help/matlab/matlab_external/system-requirements-for-matlab-engine-for-python.html>
 
 Installation:

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -13,7 +13,7 @@ For information and installation of the
 * Check to see if you pass style guidelines: `tb verify`
 
 Note: Docker and the toolbelt is an optional way of running tests and reduces the 
-work needed to maintain your python environmet. 
+work needed to maintain your python environment.
 
 ### Native python on Linux, OSX, Windows
  [Tox](http://tox.readthedocs.org/en/latest/) is used for native testing: `pip install tox`

--- a/docs/functonal-areas/crazyradio_lib.md
+++ b/docs/functonal-areas/crazyradio_lib.md
@@ -12,7 +12,7 @@ Theory of operation
 -------------------
 
 The Crazyradio is configured in PTX mode which means that it will start
-all comunication. If a device in PRX mode is on the same address,
+all communication. If a device in PRX mode is on the same address,
 channel and datarate, the device will send back an ack packet that may
 contains data.
 

--- a/examples/basiclog.py
+++ b/examples/basiclog.py
@@ -101,12 +101,12 @@ class LoggingExample:
         print('Error when logging %s: %s' % (logconf.name, msg))
 
     def _stab_log_data(self, timestamp, data, logconf):
-        """Callback froma the log API when data arrives"""
+        """Callback from a the log API when data arrives"""
         print('[%d][%s]: %s' % (timestamp, logconf.name, data))
 
     def _connection_failed(self, link_uri, msg):
         """Callback when connection initial connection fails (i.e no Crazyflie
-        at the speficied address)"""
+        at the specified address)"""
         print('Connection to %s failed: %s' % (link_uri, msg))
         self.is_connected = False
 

--- a/examples/cfbridge.py
+++ b/examples/cfbridge.py
@@ -3,8 +3,8 @@
 Bridge a Crazyflie connected to a Crazyradio to a local MAVLink port
 Requires 'pip install cflib'
 
-As the ESB protocol works using PTX and PRX (Primary Transmitter/Reciever)
-modes. Thus, data is only recieved as a response to a sent packet.
+As the ESB protocol works using PTX and PRX (Primary Transmitter/Receiver)
+modes. Thus, data is only received as a response to a sent packet.
 So, we need to constantly poll the receivers for bidirectional communication.
 
 @author: Dennis Shtatnov (densht@gmail.com)
@@ -91,12 +91,12 @@ class RadioBridge:
         print('Error when logging %s: %s' % (logconf.name, msg))
 
     def _stab_log_data(self, timestamp, data, logconf):
-        """Callback froma the log API when data arrives"""
+        """Callback from a the log API when data arrives"""
         print('[%d][%s]: %s' % (timestamp, logconf.name, data))
 
     def _connection_failed(self, link_uri, msg):
         """Callback when connection initial connection fails (i.e no Crazyflie
-        at the speficied address)"""
+        at the specified address)"""
         print('Connection to %s failed: %s' % (link_uri, msg))
         self.is_connected = False
 

--- a/examples/erase-ow.py
+++ b/examples/erase-ow.py
@@ -100,12 +100,12 @@ class EEPROMExample:
         print('Error when logging %s: %s' % (logconf.name, msg))
 
     def _stab_log_data(self, timestamp, data, logconf):
-        """Callback froma the log API when data arrives"""
+        """Callback from a the log API when data arrives"""
         print('[%d][%s]: %s' % (timestamp, logconf.name, data))
 
     def _connection_failed(self, link_uri, msg):
         """Callback when connection initial connection fails (i.e no Crazyflie
-        at the speficied address)"""
+        at the specified address)"""
         print('Connection to %s failed: %s' % (link_uri, msg))
         self.is_connected = False
 

--- a/examples/lighthouse/lighthouse_openvr_multigrab.py
+++ b/examples/lighthouse/lighthouse_openvr_multigrab.py
@@ -107,7 +107,7 @@ def start_position_printing(scf):
     log_conf.start()
 
 
-def vector_substract(v0, v1):
+def vector_subtract(v0, v1):
     return [v0[0] - v1[0], v0[1] - v1[1], v0[2] - v1[2]]
 
 
@@ -151,10 +151,10 @@ def run_sequence(scf0, scf1):
             print('Grab started')
             grab_controller_start = [-1*pose[2][3], -1*pose[0][3], pose[1][3]]
 
-            dist0 = vector_norm(vector_substract(grab_controller_start,
-                                                 setpoints[0]))
-            dist1 = vector_norm(vector_substract(grab_controller_start,
-                                                 setpoints[1]))
+            dist0 = vector_norm(vector_subtract(grab_controller_start,
+                                                setpoints[0]))
+            dist1 = vector_norm(vector_subtract(grab_controller_start,
+                                                setpoints[1]))
 
             if dist0 < dist1:
                 closest = 0
@@ -171,8 +171,8 @@ def run_sequence(scf0, scf1):
         if trigger:
             curr = [-1*pose[2][3], -1*pose[0][3], pose[1][3]]
             setpoints[closest] = vector_add(
-                grab_setpoint_start, vector_substract(curr,
-                                                      grab_controller_start))
+                grab_setpoint_start, vector_subtract(curr,
+                                                     grab_controller_start))
 
         cf0.commander.send_position_setpoint(setpoints[0][0],
                                              setpoints[0][1],

--- a/examples/lighthouse/read-geometry-mem.py
+++ b/examples/lighthouse/read-geometry-mem.py
@@ -48,7 +48,7 @@ class ReadMem:
             if count != 1:
                 raise Exception('Unexpected nr of memories found:', count)
 
-            print('Rquesting data')
+            print('Requesting data')
             mems[0].update(self._data_updated)
 
             while not self.got_data:

--- a/examples/multiranger_pointcloud.py
+++ b/examples/multiranger_pointcloud.py
@@ -37,7 +37,7 @@ Crazyflie can then be controlled by using keyboard input:
 
 There's additional setting for (see constants below):
  * Plotting the downwards sensor
- * Plotting the estimated Crazyflie postition
+ * Plotting the estimated Crazyflie position
  * Max threshold for sensors
  * Speed factor that set's how fast the Crazyflie moves
 
@@ -82,7 +82,7 @@ if len(sys.argv) > 1:
 PLOT_CF = False
 # Enable plotting of down sensor
 PLOT_SENSOR_DOWN = False
-# Set the sensor threashold (in mm)
+# Set the sensor threshold (in mm)
 SENSOR_TH = 2000
 # Set the speed factor for moving and rotating
 SPEED_FACTOR = 0.3

--- a/examples/multiranger_push.py
+++ b/examples/multiranger_push.py
@@ -25,7 +25,7 @@
 #  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 #  MA  02110-1301, USA.
 """
-Example scipts that allows a user to "push" the Crazyflie 2.0 around
+Example scripts that allows a user to "push" the Crazyflie 2.0 around
 using your hands while it's hovering.
 
 This examples uses the Flow and Multi-ranger decks to measure distances

--- a/examples/positioning/matrix_light_printer.py
+++ b/examples/positioning/matrix_light_printer.py
@@ -26,7 +26,7 @@ This script implements a simple matrix light printer to be used with a
 camera with open shutter in a dark room.
 
 It requires a Crazyflie capable of controlling its position and with
-a Led ring attached to it. A piece of sicky paper can be attached on
+a Led ring attached to it. A piece of sticky paper can be attached on
 the led ring to orient the ring light toward the front.
 
 To control it position, Crazyflie requires an absolute positioning

--- a/examples/read-eeprom.py
+++ b/examples/read-eeprom.py
@@ -94,12 +94,12 @@ class EEPROMExample:
         print('Error when logging %s: %s' % (logconf.name, msg))
 
     def _stab_log_data(self, timestamp, data, logconf):
-        """Callback froma the log API when data arrives"""
+        """Callback from a the log API when data arrives"""
         print('[%d][%s]: %s' % (timestamp, logconf.name, data))
 
     def _connection_failed(self, link_uri, msg):
         """Callback when connection initial connection fails (i.e no Crazyflie
-        at the speficied address)"""
+        at the specified address)"""
         print('Connection to %s failed: %s' % (link_uri, msg))
         self.is_connected = False
 

--- a/examples/read-ow.py
+++ b/examples/read-ow.py
@@ -101,12 +101,12 @@ class OWExample:
         print('Error when logging %s: %s' % (logconf.name, msg))
 
     def _stab_log_data(self, timestamp, data, logconf):
-        """Callback froma the log API when data arrives"""
+        """Callback from a the log API when data arrives"""
         print('[%d][%s]: %s' % (timestamp, logconf.name, data))
 
     def _connection_failed(self, link_uri, msg):
         """Callback when connection initial connection fails (i.e no Crazyflie
-        at the speficied address)"""
+        at the specified address)"""
         print('Connection to %s failed: %s' % (link_uri, msg))
         self.is_connected = False
 

--- a/examples/swarm/hl-commander-swarm.py
+++ b/examples/swarm/hl-commander-swarm.py
@@ -25,7 +25,7 @@
 Simple example of a swarm using the High level commander.
 
 The swarm takes off and flies a synchronous square shape before landing.
-The trajectories are relative to the starting positions and the Crazyfles can
+The trajectories are relative to the starting positions and the Crazyflies can
 be at any position on the floor when the script is started.
 
 This example is intended to work with any absolute positioning system.

--- a/examples/swarm/swarmSequenceCircle.py
+++ b/examples/swarm/swarmSequenceCircle.py
@@ -25,7 +25,7 @@
 #  MA  02110-1301, USA.
 """
 A script to fly 5 Crazyflies in formation. One stays in the center and the
-other four fly aound it in a circle. Mainly intended to be used with the
+other four fly around it in a circle. Mainly intended to be used with the
 Flow deck.
 The starting positions are vital and should be oriented like this
 
@@ -53,7 +53,7 @@ URI3 = 'radio://0/5/2M/E7E7E7E702'
 URI4 = 'radio://0/110/2M/E7E7E7E703'
 
 # d: diameter of circle
-# z: altituce
+# z: altitude
 params0 = {'d': 1.0, 'z': 0.3}
 params1 = {'d': 1.0, 'z': 0.3}
 params2 = {'d': 0.0, 'z': 0.5}

--- a/examples/write-eeprom.py
+++ b/examples/write-eeprom.py
@@ -106,12 +106,12 @@ class EEPROMExample:
         print('Error when logging %s: %s' % (logconf.name, msg))
 
     def _stab_log_data(self, timestamp, data, logconf):
-        """Callback froma the log API when data arrives"""
+        """Callback from the log API when data arrives"""
         print('[%d][%s]: %s' % (timestamp, logconf.name, data))
 
     def _connection_failed(self, link_uri, msg):
         """Callback when connection initial connection fails (i.e no Crazyflie
-        at the speficied address)"""
+        at the specified address)"""
         print('Connection to %s failed: %s' % (link_uri, msg))
         self.is_connected = False
 

--- a/examples/write-ow.py
+++ b/examples/write-ow.py
@@ -112,12 +112,12 @@ class WriteOwExample:
         print('Error when logging %s: %s' % (logconf.name, msg))
 
     def _stab_log_data(self, timestamp, data, logconf):
-        """Callback froma the log API when data arrives"""
+        """Callback from the log API when data arrives"""
         print('[%d][%s]: %s' % (timestamp, logconf.name, data))
 
     def _connection_failed(self, link_uri, msg):
         """Callback when connection initial connection fails (i.e no Crazyflie
-        at the speficied address)"""
+        at the specified address)"""
         print('Connection to %s failed: %s' % (link_uri, msg))
         self.is_connected = False
 

--- a/test/crazyflie/test_syncCrazyflie.py
+++ b/test/crazyflie/test_syncCrazyflie.py
@@ -145,7 +145,7 @@ class SyncCrazyflieTest(unittest.TestCase):
         self.assertFalse(self.sut.is_link_open())
         self._assertAllCallbacksAreRemoved()
 
-    def test_open_close_with_context_mangement(self):
+    def test_open_close_with_context_management(self):
         # Fixture
 
         # Test

--- a/test/positioning/test_position_hl_commander.py
+++ b/test/positioning/test_position_hl_commander.py
@@ -180,13 +180,13 @@ class TestPositionHlCommander(unittest.TestCase):
             self, sleep_mock):
         # Fixture
         self.sut.take_off()
-        inital_pos = self.sut.get_position()
+        initial_pos = self.sut.get_position()
 
         # Test
         self.sut.go_to(1.0, 2.0, 3.0, 4.0)
 
         # Assert
-        distance = self._distance(inital_pos, (1.0, 2.0, 3.0))
+        distance = self._distance(initial_pos, (1.0, 2.0, 3.0))
         duration = distance / 4.0
         self.commander_mock.go_to.assert_called_with(
             1.0, 2.0, 3.0, 0.0, duration)
@@ -196,10 +196,10 @@ class TestPositionHlCommander(unittest.TestCase):
             self, sleep_mock):
         # Fixture
         self.sut.take_off()
-        inital_pos = self.sut.get_position()
+        initial_pos = self.sut.get_position()
 
         # Test
-        self.sut.go_to(inital_pos[0], inital_pos[1], inital_pos[2])
+        self.sut.go_to(initial_pos[0], initial_pos[1], initial_pos[2])
 
         # Assert
         self.commander_mock.go_to.assert_not_called()
@@ -208,7 +208,7 @@ class TestPositionHlCommander(unittest.TestCase):
             self, sleep_mock):
         # Fixture
         self.sut.take_off()
-        inital_pos = self.sut.get_position()
+        initial_pos = self.sut.get_position()
 
         # Test
         self.sut.move_distance(1.0, 2.0, 3.0, 4.0)
@@ -217,9 +217,9 @@ class TestPositionHlCommander(unittest.TestCase):
         distance = self._distance((0.0, 0.0, 0.0), (1.0, 2.0, 3.0))
         duration = distance / 4.0
         final_pos = (
-            inital_pos[0] + 1.0,
-            inital_pos[1] + 2.0,
-            inital_pos[2] + 3.0)
+            initial_pos[0] + 1.0,
+            initial_pos[1] + 2.0,
+            initial_pos[2] + 3.0)
         self.commander_mock.go_to.assert_called_with(
             final_pos[0], final_pos[1], final_pos[2], 0.0, duration)
         sleep_mock.assert_called_with(duration)
@@ -228,7 +228,7 @@ class TestPositionHlCommander(unittest.TestCase):
             self, sleep_mock):
         # Fixture
         self.sut.take_off()
-        inital_pos = self.sut.get_position()
+        initial_pos = self.sut.get_position()
 
         # Test
         self.sut.forward(1.0, 2.0)
@@ -236,9 +236,9 @@ class TestPositionHlCommander(unittest.TestCase):
         # Assert
         duration = 1.0 / 2.0
         final_pos = (
-            inital_pos[0] + 1.0,
-            inital_pos[1],
-            inital_pos[2])
+            initial_pos[0] + 1.0,
+            initial_pos[1],
+            initial_pos[2])
         self.commander_mock.go_to.assert_called_with(
             final_pos[0], final_pos[1], final_pos[2], 0.0, duration)
         sleep_mock.assert_called_with(duration)
@@ -247,7 +247,7 @@ class TestPositionHlCommander(unittest.TestCase):
             self, sleep_mock):
         # Fixture
         self.sut.take_off()
-        inital_pos = self.sut.get_position()
+        initial_pos = self.sut.get_position()
 
         # Test
         self.sut.back(1.0, 2.0)
@@ -255,9 +255,9 @@ class TestPositionHlCommander(unittest.TestCase):
         # Assert
         duration = 1.0 / 2.0
         final_pos = (
-            inital_pos[0] - 1.0,
-            inital_pos[1],
-            inital_pos[2])
+            initial_pos[0] - 1.0,
+            initial_pos[1],
+            initial_pos[2])
         self.commander_mock.go_to.assert_called_with(
             final_pos[0], final_pos[1], final_pos[2], 0.0, duration)
         sleep_mock.assert_called_with(duration)
@@ -266,7 +266,7 @@ class TestPositionHlCommander(unittest.TestCase):
             self, sleep_mock):
         # Fixture
         self.sut.take_off()
-        inital_pos = self.sut.get_position()
+        initial_pos = self.sut.get_position()
 
         # Test
         self.sut.left(1.0, 2.0)
@@ -274,9 +274,9 @@ class TestPositionHlCommander(unittest.TestCase):
         # Assert
         duration = 1.0 / 2.0
         final_pos = (
-            inital_pos[0],
-            inital_pos[1] + 1.0,
-            inital_pos[2])
+            initial_pos[0],
+            initial_pos[1] + 1.0,
+            initial_pos[2])
         self.commander_mock.go_to.assert_called_with(
             final_pos[0], final_pos[1], final_pos[2], 0.0, duration)
         sleep_mock.assert_called_with(duration)
@@ -285,7 +285,7 @@ class TestPositionHlCommander(unittest.TestCase):
             self, sleep_mock):
         # Fixture
         self.sut.take_off()
-        inital_pos = self.sut.get_position()
+        initial_pos = self.sut.get_position()
 
         # Test
         self.sut.right(1.0, 2.0)
@@ -293,9 +293,9 @@ class TestPositionHlCommander(unittest.TestCase):
         # Assert
         duration = 1.0 / 2.0
         final_pos = (
-            inital_pos[0],
-            inital_pos[1] - 1,
-            inital_pos[2])
+            initial_pos[0],
+            initial_pos[1] - 1,
+            initial_pos[2])
         self.commander_mock.go_to.assert_called_with(
             final_pos[0], final_pos[1], final_pos[2], 0, duration)
         sleep_mock.assert_called_with(duration)
@@ -304,7 +304,7 @@ class TestPositionHlCommander(unittest.TestCase):
             self, sleep_mock):
         # Fixture
         self.sut.take_off()
-        inital_pos = self.sut.get_position()
+        initial_pos = self.sut.get_position()
 
         # Test
         self.sut.up(1.0, 2.0)
@@ -312,9 +312,9 @@ class TestPositionHlCommander(unittest.TestCase):
         # Assert
         duration = 1.0 / 2.0
         final_pos = (
-            inital_pos[0],
-            inital_pos[1],
-            inital_pos[2] + 1)
+            initial_pos[0],
+            initial_pos[1],
+            initial_pos[2] + 1)
         self.commander_mock.go_to.assert_called_with(
             final_pos[0], final_pos[1], final_pos[2], 0, duration)
         sleep_mock.assert_called_with(duration)
@@ -323,7 +323,7 @@ class TestPositionHlCommander(unittest.TestCase):
             self, sleep_mock):
         # Fixture
         self.sut.take_off()
-        inital_pos = self.sut.get_position()
+        initial_pos = self.sut.get_position()
 
         # Test
         self.sut.down(1.0, 2.0)
@@ -331,9 +331,9 @@ class TestPositionHlCommander(unittest.TestCase):
         # Assert
         duration = 1.0 / 2.0
         final_pos = (
-            inital_pos[0],
-            inital_pos[1],
-            inital_pos[2] - 1)
+            initial_pos[0],
+            initial_pos[1],
+            initial_pos[2] - 1)
         self.commander_mock.go_to.assert_called_with(
             final_pos[0], final_pos[1], final_pos[2], 0, duration)
         sleep_mock.assert_called_with(duration)
@@ -342,14 +342,14 @@ class TestPositionHlCommander(unittest.TestCase):
             self, sleep_mock):
         # Fixture
         self.sut.take_off()
-        inital_pos = self.sut.get_position()
+        initial_pos = self.sut.get_position()
         self.sut.set_default_velocity(7)
 
         # Test
         self.sut.go_to(1.0, 2.0, 3.0)
 
         # Assert
-        distance = self._distance(inital_pos, (1.0, 2.0, 3.0))
+        distance = self._distance(initial_pos, (1.0, 2.0, 3.0))
         duration = distance / 7.0
         self.commander_mock.go_to.assert_called_with(
             1.0, 2.0, 3.0, 0.0, duration)
@@ -359,7 +359,7 @@ class TestPositionHlCommander(unittest.TestCase):
             self, sleep_mock):
         # Fixture
         self.sut.take_off()
-        inital_pos = self.sut.get_position()
+        initial_pos = self.sut.get_position()
         self.sut.set_default_velocity(7.0)
         self.sut.set_default_height(5.0)
 
@@ -367,7 +367,7 @@ class TestPositionHlCommander(unittest.TestCase):
         self.sut.go_to(1.0, 2.0)
 
         # Assert
-        distance = self._distance(inital_pos, (1.0, 2.0, 5.0))
+        distance = self._distance(initial_pos, (1.0, 2.0, 5.0))
         duration = distance / 7.0
         self.commander_mock.go_to.assert_called_with(
             1.0, 2.0, 5.0, 0.0, duration)


### PR DESCRIPTION
Fix typos in project documentation, docstrings, and some code segments. There are still a few remaining misspelled methods and argument names; however, changing them _may_ break backwards compatibility for some dependents, but they're readability is not largely impacted.

While the scope of this PR is quite large, the impact to anything other than readability should be nonexistent so I have not created an associated issue.