### PR TITLE
Fix argument name of RadioDriver.receive_packet

### DIFF
--- a/cflib/crtp/radiodriver.py
+++ b/cflib/crtp/radiodriver.py
@@ -334,24 +334,24 @@ class RadioDriver(CRTPDriver):
 
         return devid, channel, datarate, address
 
-    def receive_packet(self, time=0):
+    def receive_packet(self, wait=0):
         """
         Receive a packet though the link. This call is blocking but will
         timeout and return None if a timeout is supplied.
         """
-        if time == 0:
+        if wait == 0:
             try:
                 return self.in_queue.get(False)
             except queue.Empty:
                 return None
-        elif time < 0:
+        elif wait < 0:
             try:
                 return self.in_queue.get(True)
             except queue.Empty:
                 return None
         else:
             try:
-                return self.in_queue.get(True, time)
+                return self.in_queue.get(True, wait)
             except queue.Empty:
                 return None
 

--- a/sys_test/swarm_test_rig/test_response_time.py
+++ b/sys_test/swarm_test_rig/test_response_time.py
@@ -108,7 +108,7 @@ class TestResponseTime(unittest.TestCase):
         while time.time() < time_end:
             for link in links:
                 if link.uri not in response_timestamps:
-                    response = link.receive_packet(time=NO_BLOCKING)
+                    response = link.receive_packet(wait=NO_BLOCKING)
                     if self._is_response_correct_seq_nr(response, seq_nr):
                         response_timestamps[link.uri] = time.time()
 


### PR DESCRIPTION
The original definition is that function is to have an argument called
wait, not time, see https://github.com/bitcraze/crazyflie-lib-python/blob/master/cflib/crtp/crtpdriver.py#L59

Part of issue #196.