### PR TITLE
Add CfLinkCppDriver

### DIFF
--- a/cflib/crtp/__init__.py
+++ b/cflib/crtp/__init__.py
@@ -26,6 +26,7 @@
 #  MA  02110-1301, USA.
 """Scans and creates communication interfaces."""
 import logging
+import os
 
 from .debugdriver import DebugDriver
 from .exceptions import WrongUriType
@@ -41,25 +42,26 @@ __all__ = []
 logger = logging.getLogger(__name__)
 
 
-DRIVERS = [RadioDriver, SerialDriver, UdpDriver,
-           DebugDriver, UsbDriver, PrrtDriver]
 CLASSES = []
 
 
 def init_drivers(enable_debug_driver=False, enable_serial_driver=False):
     """Initialize all the drivers."""
-    for driver in DRIVERS:
-        try:
-            enable = True
-            if driver == DebugDriver:
-                enable = enable_debug_driver
-            elif driver == SerialDriver:
-                enable = enable_serial_driver
 
-            if enable:
-                CLASSES.append(driver)
-        except Exception:  # pylint: disable=W0703
-            continue
+    env = os.getenv('USE_CFLINK')
+    if env is not None and env == 'cpp':
+        from .cflinkcppdriver import CfLinkCppDriver
+        CLASSES.append(CfLinkCppDriver)
+    else:
+        CLASSES.extend([RadioDriver, UsbDriver])
+
+    if enable_debug_driver:
+        CLASSES.append(DebugDriver)
+
+    if enable_serial_driver:
+        CLASSES.append(SerialDriver)
+
+    CLASSES.extend([UdpDriver, PrrtDriver])
 
 
 def scan_interfaces(address=None):

--- a/cflib/crtp/cflinkcppdriver.py
+++ b/cflib/crtp/cflinkcppdriver.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#     ||          ____  _ __
+#  +------+      / __ )(_) /_______________ _____  ___
+#  | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+#  +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#   ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+#  Copyright (C) 2011-2021 Bitcraze AB
+#
+#  Crazyflie Nano Quadcopter Client
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA  02110-1301, USA.
+"""
+Crazyflie driver using the cflinkcpp implementation.
+
+This driver is used to communicate over the radio or USB.
+"""
+import threading
+import logging
+import os
+
+from .crtpstack import CRTPPacket
+from cflib.crtp.crtpdriver import CRTPDriver
+import cflinkcpp
+
+__author__ = 'Bitcraze AB'
+__all__ = ['CfLinkCppDriver']
+
+logger = logging.getLogger(__name__)
+
+
+class CfLinkCppDriver(CRTPDriver):
+    """ cflinkcpp driver """
+
+    def __init__(self):
+        """Driver constructor. Throw an exception if the driver is unable to
+        open the URI
+        """
+        self.uri = ''
+
+        # cflinkcpp resends packets internally
+        self.needs_resending = False
+
+        self._connection = None
+
+    def connect(self, uri, link_quality_callback, link_error_callback):
+        """Connect the driver to a specified URI
+
+        @param uri Uri of the link to open
+        @param link_quality_callback Callback to report link quality in percent
+        @param link_error_callback Callback to report errors (will result in
+               disconnection)
+        """
+
+        self._connection = cflinkcpp.Connection(uri)
+        self.uri = uri
+        self._link_quality_callback = link_quality_callback
+        self._link_error_callback = link_error_callback
+        if link_quality_callback is not None or link_error_callback is not None:
+            self._last_connection_stats = self._connection.statistics
+            self._recompute_link_quality_timer()
+
+    def send_packet(self, pk):
+        """Send a CRTP packet"""
+        nativePk = cflinkcpp.Packet()
+        nativePk.port = pk.port
+        nativePk.channel = pk.channel
+        nativePk.payload = bytes(pk.data)
+        try:
+            self._connection.send(nativePk)
+        except Exception as e:
+            if self._link_error_callback is not None:
+                import traceback
+                self._link_error_callback(
+                    'Error communicating! Perhaps your device has been unplugged?\n'
+                    'Exception:{}\n\n{}'.format(e, traceback.format_exc()))
+
+
+    def receive_packet(self, wait=0):
+        """Receive a CRTP packet.
+
+        @param wait The time to wait for a packet in second. -1 means forever
+
+        @return One CRTP packet or None if no packet has been received.
+        """
+        if wait < 0:
+            # Since we block in the native lib, break up infinity timeouts into smaller
+            # pieces, so Ctrl+C keeps working as expected
+            timeout = 100
+        elif wait == 0:
+            timeout = 1
+        else:
+            timeout = int(wait*1000)
+
+        try:
+            while True:
+                nativePk = self._connection.recv(timeout=timeout)
+                if wait>=0 or nativePk.valid:
+                    break
+
+            if not nativePk.valid:
+                return None
+
+            pk = CRTPPacket()
+            pk.port = nativePk.port
+            pk.channel = nativePk.channel
+            pk.data = nativePk.payload
+            return pk
+        except Exception as e:
+            if self._link_error_callback is not None:
+                import traceback
+                self._link_error_callback(
+                    'Error communicating! Perhaps your device has been unplugged?\n'
+                    'Exception:{}\n\n{}'.format(e, traceback.format_exc()))
+        
+    def get_status(self):
+        """
+        Return a status string from the interface.
+        """
+        "okay"
+
+    def get_name(self):
+        """
+        Return a human readable name of the interface.
+        """
+        "cflinkcpp"
+
+    def scan_interface(self, address=None):
+        """
+        Scan interface for available Crazyflie quadcopters and return a list
+        with them.
+        """
+        if address:
+            uris = cflinkcpp.Connection.scan(address)
+        else:
+            uris = cflinkcpp.Connection.scan()
+        # convert to list of tuples, where the second part is a comment
+        result = [(uri, '') for uri in uris]
+        return result
+
+    def scan_selected(self, uris):
+        """
+        Scan interface for available Crazyflie quadcopters and return a list
+        with them.
+        """
+        return cflinkcpp.Connection.scan_selected(uris)
+
+    def enum(self):
+        """Enumerate, and return a list, of the available link URI on this
+        system
+        """
+        return self.scan_interface()
+
+    def get_help(self):
+        """return the help message on how to form the URI for this driver
+        None means no help
+        """
+        ""
+
+    def close(self):
+        """Close the link"""
+        self._connection.close()
+        self._connection = None
+
+    def _recompute_link_quality_timer(self):
+        if self._connection is None:
+            return
+        stats = self._connection.statistics
+        sent_count = stats.sent_count - self._last_connection_stats.sent_count
+        ack_count = stats.ack_count - self._last_connection_stats.ack_count
+        if sent_count > 0:
+            link_quality = min(ack_count, sent_count) / sent_count * 100.0
+        else:
+            link_quality = 1
+        self._last_connection_stats = stats
+
+        if self._link_quality_callback is not None:
+            self._link_quality_callback(link_quality)
+
+        if sent_count > 10 and ack_count == 0 and self._link_error_callback is not None:
+            self._link_error_callback('Too many packets lost')
+
+        threading.Timer(1.0, self._recompute_link_quality_timer).start()

--- a/cflib/crtp/cflinkcppdriver.py
+++ b/cflib/crtp/cflinkcppdriver.py
@@ -29,13 +29,13 @@ Crazyflie driver using the cflinkcpp implementation.
 
 This driver is used to communicate over the radio or USB.
 """
-import threading
 import logging
-import os
+import threading
+
+import cflinkcpp
 
 from .crtpstack import CRTPPacket
 from cflib.crtp.crtpdriver import CRTPDriver
-import cflinkcpp
 
 __author__ = 'Bitcraze AB'
 __all__ = ['CfLinkCppDriver']
@@ -89,7 +89,6 @@ class CfLinkCppDriver(CRTPDriver):
                     'Error communicating! Perhaps your device has been unplugged?\n'
                     'Exception:{}\n\n{}'.format(e, traceback.format_exc()))
 
-
     def receive_packet(self, wait=0):
         """Receive a CRTP packet.
 
@@ -109,7 +108,7 @@ class CfLinkCppDriver(CRTPDriver):
         try:
             while True:
                 nativePk = self._connection.recv(timeout=timeout)
-                if wait>=0 or nativePk.valid:
+                if wait >= 0 or nativePk.valid:
                     break
 
             if not nativePk.valid:
@@ -126,18 +125,18 @@ class CfLinkCppDriver(CRTPDriver):
                 self._link_error_callback(
                     'Error communicating! Perhaps your device has been unplugged?\n'
                     'Exception:{}\n\n{}'.format(e, traceback.format_exc()))
-        
+
     def get_status(self):
         """
         Return a status string from the interface.
         """
-        "okay"
+        'okay'
 
     def get_name(self):
         """
         Return a human readable name of the interface.
         """
-        "cflinkcpp"
+        'cflinkcpp'
 
     def scan_interface(self, address=None):
         """
@@ -169,7 +168,7 @@ class CfLinkCppDriver(CRTPDriver):
         """return the help message on how to form the URI for this driver
         None means no help
         """
-        ""
+        ''
 
     def close(self):
         """Close the link"""

--- a/cflib/utils/power_switch.py
+++ b/cflib/utils/power_switch.py
@@ -37,7 +37,7 @@ class PowerSwitch:
 
     def __init__(self, uri):
         self.uri = uri
-        uri_augmented = uri+'[noSafelink][noAutoPing][noAckFilter]'
+        uri_augmented = uri+'?safelink=0&autoping=0&ackfilter=0'
         self.link = cflib.crtp.get_link_driver(uri_augmented)
         # Switch to legacy mode, if uri options are not available
         if not self.link:

--- a/cflib/utils/power_switch.py
+++ b/cflib/utils/power_switch.py
@@ -26,6 +26,7 @@ a Crazyradio.
 import time
 
 import cflib.crtp
+from cflib.crtp.crtpstack import CRTPPacket
 from cflib.crtp.radiodriver import RadioManager
 
 
@@ -36,11 +37,15 @@ class PowerSwitch:
 
     def __init__(self, uri):
         self.uri = uri
-        uri_parts = cflib.crtp.RadioDriver.parse_uri(uri)
-        self.devid = uri_parts[0]
-        self.channel = uri_parts[1]
-        self.datarate = uri_parts[2]
-        self.address = uri_parts[3]
+        uri_augmented = uri+'[noSafelink][noAutoPing][noAckFilter]'
+        self.link = cflib.crtp.get_link_driver(uri_augmented)
+        # Switch to legacy mode, if uri options are not available
+        if not self.link:
+            uri_parts = cflib.crtp.RadioDriver.parse_uri(uri)
+            self.devid = uri_parts[0]
+            self.channel = uri_parts[1]
+            self.datarate = uri_parts[2]
+            self.address = uri_parts[3]
 
     def platform_power_down(self):
         """ Power down the platform, both NRF and STM MCUs.
@@ -64,26 +69,41 @@ class PowerSwitch:
         time.sleep(1)
         self.stm_power_up()
 
+    def close(self):
+        if self.link:
+            self.link.close()
+
     def _send(self, cmd):
-        packet = [0xf3, 0xfe, cmd]
+        if not self.link:
+            packet = [0xf3, 0xfe, cmd]
 
-        cr = RadioManager.open(devid=self.devid)
-        cr.set_channel(self.channel)
-        cr.set_data_rate(self.datarate)
-        cr.set_address(self.address)
-        cr.set_arc(3)
+            cr = RadioManager.open(devid=self.devid)
+            cr.set_channel(self.channel)
+            cr.set_data_rate(self.datarate)
+            cr.set_address(self.address)
+            cr.set_arc(3)
 
-        success = False
-        for i in range(50):
-            res = cr.send_packet(packet)
-            if res and res.ack:
-                success = True
-                break
+            success = False
+            for i in range(50):
+                res = cr.send_packet(packet)
+                if res and res.ack:
+                    success = True
+                    break
 
-            time.sleep(0.01)
+                time.sleep(0.01)
 
-        cr.close()
+            cr.close()
 
-        if not success:
-            raise Exception(
-                'Failed to connect to Crazyflie at {}'.format(self.uri))
+            if not success:
+                raise Exception(
+                    'Failed to connect to Crazyflie at {}'.format(self.uri))
+        else:
+
+            # send command (will be repeated until acked)
+            pk = CRTPPacket(0xFF, [0xfe, cmd])
+            self.link.send_packet(pk)
+            # wait up to 1s
+            pk = self.link.receive_packet(0.1)
+            if pk is None:
+                raise Exception(
+                    'Failed to connect to Crazyflie at {}'.format(self.uri))


### PR DESCRIPTION
This backend is an alternative to both RadioDriver and UsbDriver and
uses cflinkcpp, a C++ library with Python bindings.
It can be enabled by setting the environment variable USE_CFLINK=cpp.
The default is to use the existing pure Python implementation.

Part of issue #196.