### PR TITLE
Add synchronous flavour of mapped deck memory functionality

### DIFF
--- a/cflib/crazyflie/mem/deck_memory.py
+++ b/cflib/crazyflie/mem/deck_memory.py
@@ -262,6 +262,7 @@ class DeckMemoryManager(MemoryElement):
 
 class SyncDeckMemoryManager:
     """A wrapper for the DeckMemoryManager class to make calls synchronous and avoid callbacks"""
+
     def __init__(self, deck_memory_manager):
         self._deck_memory_manager = deck_memory_manager
 

--- a/cflib/crazyflie/mem/deck_memory.py
+++ b/cflib/crazyflie/mem/deck_memory.py
@@ -95,9 +95,10 @@ class DeckMemory:
         return (self._bit_field & self.MASK_BOOTLOADER_ACTIVE) != 0
 
     def _parse(self, data):
-        self._bit_field, self.required_hash, self.required_length, self._base_address, _name = struct.unpack(
-            '<BLLL19s', data)
-        self.name = _name.decode()
+        self._bit_field = struct.unpack('<B', data[0:1])[0]
+        if self.is_valid:
+            self.required_hash, self.required_length, self._base_address, _name = struct.unpack('<LLL19s', data[1:])
+            self.name = _name.split(b'\x00')[0].decode()
 
 
 class DeckMemoryManager(MemoryElement):

--- a/cflib/utils/callbacks.py
+++ b/cflib/utils/callbacks.py
@@ -27,7 +27,6 @@
 """
 Callback objects used in the Crazyflie library
 """
-
 from threading import Event
 
 __author__ = 'Bitcraze AB'
@@ -59,6 +58,7 @@ class Caller():
 
 class Syncer:
     """A class to create syncronous behaviour for methods using callbacks"""
+
     def __init__(self):
         self._event = Event()
         self.success_args = None

--- a/cflib/utils/callbacks.py
+++ b/cflib/utils/callbacks.py
@@ -28,6 +28,8 @@
 Callback objects used in the Crazyflie library
 """
 
+from threading import Event
+
 __author__ = 'Bitcraze AB'
 __all__ = ['Caller']
 
@@ -53,3 +55,28 @@ class Caller():
         copy_of_callbacks = list(self.callbacks)
         for cb in copy_of_callbacks:
             cb(*args)
+
+
+class Syncer:
+    """A class to create syncronous behaviour for methods using callbacks"""
+    def __init__(self):
+        self._event = Event()
+        self.success_args = None
+        self.failure_args = None
+        self.is_success = False
+
+    def success_cb(self, *args):
+        self.success_args = args
+        self.is_success = True
+        self._event.set()
+
+    def failure_cb(self, *args):
+        self.failure_args = args
+        self.is_success = False
+        self._event.set()
+
+    def wait(self):
+        self._event.wait()
+
+    def clear(self):
+        self._event.clear()


### PR DESCRIPTION
The mapped deck memory has an asynchronous API. Add synchronous wrappers to make it easy to use the API from a simple script.