### PR TITLE
Make system_type in LighthouseConfigWriter.write_and_store_config() optional

### DIFF
--- a/cflib/localization/lighthouse_config_manager.py
+++ b/cflib/localization/lighthouse_config_manager.py
@@ -118,8 +118,7 @@ class LighthouseConfigWriter:
         self._write_failed_for_one_or_more_objects = False
         self._nr_of_base_stations = nr_of_base_stations
 
-    def write_and_store_config(self, data_stored_cb, geos=None, calibs=None,
-                               system_type=LighthouseConfigFileManager.SYSTEM_TYPE_V2):
+    def write_and_store_config(self, data_stored_cb, geos=None, calibs=None, system_type=None):
         """
         Transfer geometry and calibration data to the Crazyflie and persist to permanent storage.
         The callback is called when done.
@@ -146,16 +145,17 @@ class LighthouseConfigWriter:
 
         self._write_failed_for_one_or_more_objects = False
 
-        # Change system type first as this will erase calib and geo data in the CF.
-        # Changing system type may trigger a lengthy operation (up to 0.5 s) if the persistant memory requires defrag.
-        # Setting a param is an asynchronous operataion, and it is not possible to know if the system swich is finished
-        # before we continue.
-        self._cf.param.set_value('lighthouse.systemType', system_type)
+        if system_type is not None:
+            # Change system type first as this will erase calib and geo data in the CF.
+            # Changing system type may trigger a lengthy operation (up to 0.5 s) if the persistant memory requires defrag.
+            # Setting a param is an asynchronous operataion, and it is not possible to know if the system swich is finished
+            # before we continue.
+            self._cf.param.set_value('lighthouse.systemType', system_type)
 
-        # We add a sleep here to make sure the change of system type is finished. It is dirty but will have to do for
-        # now. A more propper solution would be to add support for Remote Procedure Calls (RPC) with synchronous
-        # function calls.
-        time.sleep(0.8)
+            # We add a sleep here to make sure the change of system type is finished. It is dirty but will have to do for
+            # now. A more propper solution would be to add support for Remote Procedure Calls (RPC) with synchronous
+            # function calls.
+            time.sleep(0.8)
 
         self._next()
 

--- a/cflib/localization/lighthouse_config_manager.py
+++ b/cflib/localization/lighthouse_config_manager.py
@@ -147,14 +147,14 @@ class LighthouseConfigWriter:
 
         if system_type is not None:
             # Change system type first as this will erase calib and geo data in the CF.
-            # Changing system type may trigger a lengthy operation (up to 0.5 s) if the persistant memory requires defrag.
-            # Setting a param is an asynchronous operataion, and it is not possible to know if the system swich is finished
-            # before we continue.
+            # Changing system type may trigger a lengthy operation (up to 0.5 s) if the persistant memory requires
+            # defrag. Setting a param is an asynchronous operataion, and it is not possible to know if the system
+            # swich is finished before we continue.
             self._cf.param.set_value('lighthouse.systemType', system_type)
 
-            # We add a sleep here to make sure the change of system type is finished. It is dirty but will have to do for
-            # now. A more propper solution would be to add support for Remote Procedure Calls (RPC) with synchronous
-            # function calls.
+            # We add a sleep here to make sure the change of system type is finished. It is dirty but will have to
+            # do for now. A more propper solution would be to add support for Remote Procedure Calls (RPC) with
+            # synchronous function calls.
             time.sleep(0.8)
 
         self._next()


### PR DESCRIPTION
LighthouseConfigWriter.write_and_store_config() is used to write geo, config and system type data to a Crazyflie. All arguments should be optional to enable a client to chose what to write. Currently the system_type is set to LH V2 by default, but should be changed to None. The behaviour should also change so that no system type is set in the CF if system_type == None



