### PR TITLE
Add emergency stop and emergency stop watchdog support.

### DIFF
--- a/cflib/crazyflie/localization.py
+++ b/cflib/crazyflie/localization.py
@@ -169,6 +169,28 @@ class Localization():
         pk.data = struct.pack('<BB', self.LPS_SHORT_LPP_PACKET, dest_id) + data
         self._cf.send_packet(pk)
 
+    def send_emergency_stop(self):
+        """
+        Send emergency stop
+        """
+
+        pk = CRTPPacket()
+        pk.port = CRTPPort.LOCALIZATION
+        pk.channel = self.GENERIC_CH
+        pk.data = struct.pack('<B', self.EMERGENCY_STOP)
+        self._cf.send_packet(pk)
+
+    def send_emergency_stop_watchdog(self):
+        """
+        Send emergency stop watchdog
+        """
+
+        pk = CRTPPacket()
+        pk.port = CRTPPort.LOCALIZATION
+        pk.channel = self.GENERIC_CH
+        pk.data = struct.pack('<B', self.EMERGENCY_STOP_WATCHDOG)
+        self._cf.send_packet(pk)
+
     def send_lh_persist_data_packet(self, geo_list, calib_list):
         """
         Send geometry and calibration data to persistent memory subsystem


### PR DESCRIPTION
Emergency stop packets were added to the firmware May 2017
(commit 1e9c08c0ffc942dd0999f8b8dbbecfdfec2a84c7, firmware issue 226),
but they are not supported in the lib, yet. This change adds
send_emergency_stop and send_emergency_stop_watchdog to the
Localization class.