### PR TITLE
Set cflinkcpp as default link driver on x86_64

### DIFF
--- a/cflib/crtp/__init__.py
+++ b/cflib/crtp/__init__.py
@@ -26,7 +26,7 @@
 #  MA  02110-1301, USA.
 """Scans and creates communication interfaces."""
 import logging
-import os
+import platform
 
 from .exceptions import WrongUriType
 from .prrtdriver import PrrtDriver
@@ -47,8 +47,11 @@ CLASSES = []
 def init_drivers(enable_debug_driver=False, enable_serial_driver=False):
     """Initialize all the drivers."""
 
-    env = os.getenv('USE_CFLINK')
-    if env is not None and env == 'cpp':
+    #
+    # Right now cflinkcpp only supports x86_64, see setup.py for more info:
+    #
+    mach = platform.machine()
+    if mach in ['x86_64']:
         from .cflinkcppdriver import CfLinkCppDriver
         CLASSES.append(CfLinkCppDriver)
     else:

--- a/cflib/crtp/__init__.py
+++ b/cflib/crtp/__init__.py
@@ -26,6 +26,7 @@
 #  MA  02110-1301, USA.
 """Scans and creates communication interfaces."""
 import logging
+import os
 import platform
 
 from .exceptions import WrongUriType
@@ -47,15 +48,28 @@ CLASSES = []
 def init_drivers(enable_debug_driver=False, enable_serial_driver=False):
     """Initialize all the drivers."""
 
-    #
-    # Right now cflinkcpp only supports x86_64, see setup.py for more info:
-    #
-    mach = platform.machine()
-    if mach in ['x86_64']:
+    def append_cpp():
         from .cflinkcppdriver import CfLinkCppDriver
         CLASSES.append(CfLinkCppDriver)
-    else:
+
+    def append_python():
         CLASSES.extend([RadioDriver, UsbDriver])
+
+    env = os.getenv('USE_CFLINK')
+    if env is None:  # this is default behavior
+        mach = platform.machine()  # cflinkcpp only supports x86_64
+        if mach in ['x86_64']:
+            append_cpp()
+        else:  # on non-x86_64 machines, fall-back to python
+            append_python()
+
+    else:  # if USE_CFLINK override is used, enforce it.
+        if env == 'cpp':
+            append_cpp()
+        elif env == 'python':
+            append_python()
+        else:
+            raise Exception('The cflink "{}" is not supported'.format(env))
 
     if enable_debug_driver:
         logger.warn('The debug driver is no longer supported!')

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,17 @@
 #!/usr/bin/env python3
+import platform
+
 from setuptools import find_packages
 from setuptools import setup
+
+extra_required = []
+#
+# For now we only require the CPP native radio link driver on x86_64
+# since we only build and test on that platform. This will probably change.
+# And probably faster if you request it.
+#
+if platform.machine() == 'x86_64':
+    extra_required.extend(['cflinkcpp>=1.0a3'])
 
 setup(
     name='cflib',
@@ -26,8 +37,8 @@ setup(
 
     install_requires=[
         'pyusb>=1.0.0b2',
-        'opencv-python-headless==4.5.1.48'
-    ],
+        'opencv-python-headless==4.5.1.48',
+    ] + extra_required,
 
     # $ pip install -e .[dev]
     extras_require={


### PR DESCRIPTION
- Radiodriver: Set cflinkcpp as default
- setup.py: Require cflinkcpp on x86_64

Closes: #196

