### PR TITLE
Made possible to give a velocity command and rate input at the same time for motion commander

### DIFF
--- a/cflib/positioning/motion_commander.py
+++ b/cflib/positioning/motion_commander.py
@@ -385,7 +385,7 @@ class MotionCommander:
 
     def start_linear_motion(self, velocity_x_m, velocity_y_m, velocity_z_m, rate_yaw=0.0):
         """
-        Start a linear motion. This function returns immediately.
+        Start a linear motion with an optional yaw rate input. This function returns immediately.
 
         positive X is forward
         positive Y is left
@@ -394,6 +394,7 @@ class MotionCommander:
         :param velocity_x_m: The velocity along the X-axis (meters/second)
         :param velocity_y_m: The velocity along the Y-axis (meters/second)
         :param velocity_z_m: The velocity along the Z-axis (meters/second)
+        :param rate: The angular rate (degrees/second)
         :return:
         """
         self._set_vel_setpoint(

--- a/cflib/positioning/motion_commander.py
+++ b/cflib/positioning/motion_commander.py
@@ -399,6 +399,23 @@ class MotionCommander:
         self._set_vel_setpoint(
             velocity_x_m, velocity_y_m, velocity_z_m, 0.0)
 
+    def start_motion(self, velocity_x_m, velocity_y_m, velocity_z_m, rate):
+        """
+        Start a velocity motion with yaw rate input. This function returns immediately.
+
+        positive X is forward
+        positive Y is left
+        positive Z is up
+
+        :param velocity_x_m: The velocity along the X-axis (meters/second)
+        :param velocity_y_m: The velocity along the Y-axis (meters/second)
+        :param velocity_z_m: The velocity along the Z-axis (meters/second)
+        :param rate: The angular rate (degrees/second)
+        :return:
+        """
+        self._set_vel_setpoint(
+            velocity_x_m, velocity_y_m, velocity_z_m, rate)
+
     def _set_vel_setpoint(self, velocity_x, velocity_y, velocity_z, rate_yaw):
         if not self._is_flying:
             raise Exception('Can not move on the ground. Take off first!')

--- a/cflib/positioning/motion_commander.py
+++ b/cflib/positioning/motion_commander.py
@@ -383,7 +383,7 @@ class MotionCommander:
 
         self._set_vel_setpoint(velocity, 0.0, 0.0, rate)
 
-    def start_linear_motion(self, velocity_x_m, velocity_y_m, velocity_z_m, rate_yaw = 0.0):
+    def start_linear_motion(self, velocity_x_m, velocity_y_m, velocity_z_m, rate_yaw=0.0):
         """
         Start a linear motion. This function returns immediately.
 

--- a/cflib/positioning/motion_commander.py
+++ b/cflib/positioning/motion_commander.py
@@ -383,7 +383,7 @@ class MotionCommander:
 
         self._set_vel_setpoint(velocity, 0.0, 0.0, rate)
 
-    def start_linear_motion(self, velocity_x_m, velocity_y_m, velocity_z_m):
+    def start_linear_motion(self, velocity_x_m, velocity_y_m, velocity_z_m, rate_yaw = 0.0):
         """
         Start a linear motion. This function returns immediately.
 
@@ -397,24 +397,7 @@ class MotionCommander:
         :return:
         """
         self._set_vel_setpoint(
-            velocity_x_m, velocity_y_m, velocity_z_m, 0.0)
-
-    def start_motion(self, velocity_x_m, velocity_y_m, velocity_z_m, rate):
-        """
-        Start a velocity motion with yaw rate input. This function returns immediately.
-
-        positive X is forward
-        positive Y is left
-        positive Z is up
-
-        :param velocity_x_m: The velocity along the X-axis (meters/second)
-        :param velocity_y_m: The velocity along the Y-axis (meters/second)
-        :param velocity_z_m: The velocity along the Z-axis (meters/second)
-        :param rate: The angular rate (degrees/second)
-        :return:
-        """
-        self._set_vel_setpoint(
-            velocity_x_m, velocity_y_m, velocity_z_m, rate)
+            velocity_x_m, velocity_y_m, velocity_z_m, rate_yaw)
 
     def _set_vel_setpoint(self, velocity_x, velocity_y, velocity_z, rate_yaw):
         if not self._is_flying:


### PR DESCRIPTION
There has been a request to open up the _set_vel_setpoint to be able to give simultaneous velocity setpoint and yaw rate setpoint from the motion commander. 

https://forum.bitcraze.io/viewtopic.php?f=19&t=4855

 