### PR TITLE
Allow nonzero landing height in PositionHlCommander

### DIFF
--- a/cflib/positioning/position_hl_commander.py
+++ b/cflib/positioning/position_hl_commander.py
@@ -64,7 +64,7 @@ class PositionHlCommander:
         :param default_velocity: the default velocity to use
         :param default_height: the default height to fly at
         :param controller: Which underlying controller to use
-        :param default_landing_height: If taking off/landing on objects higher than ground, set this parameter to ensure proper landing
+        :param default_landing_height: Landing height (zero if not specified); for landing on objects off the ground
         """
         if isinstance(crazyflie, SyncCrazyflie):
             self._cf = crazyflie.cf
@@ -299,6 +299,6 @@ class PositionHlCommander:
     def set_landing_height(self, landing_height):
         """
         Set the landing height to a specific value
-        Use this function to land on objects that are at non-zero height                
+        Use this function to land on objects that are at non-zero height
         """
         self._default_landing_height = landing_height

--- a/cflib/positioning/position_hl_commander.py
+++ b/cflib/positioning/position_hl_commander.py
@@ -121,7 +121,7 @@ class PositionHlCommander:
         time.sleep(duration_s)
         self._z = height
 
-    def land(self, velocity=DEFAULT, landing_height=0.0):
+    def land(self, velocity=DEFAULT, landing_height=DEFAULT):
         """
         Go straight down and turn off the motors.
 
@@ -132,6 +132,7 @@ class PositionHlCommander:
         :return:
         """
         if self._is_flying:
+            landing_height = self._landing_height(landing_height)
             duration_s = (self._z - landing_height) / self._velocity(velocity)
             self._hl_commander.land(landing_height, duration_s)
             time.sleep(duration_s)
@@ -145,7 +146,7 @@ class PositionHlCommander:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.land(landing_height=self._default_landing_height)
+        self.land()
 
     def left(self, distance_m, velocity=DEFAULT):
         """
@@ -295,6 +296,11 @@ class PositionHlCommander:
         if height is self.DEFAULT:
             return self._default_height
         return height
+
+    def _landing_height(self, landing_height):
+        if landing_height is self.DEFAULT:
+            return self._default_landing_height
+        return landing_height
  
     def set_landing_height(self, landing_height):
         """

--- a/examples/position_commander_demo.py
+++ b/examples/position_commander_demo.py
@@ -73,7 +73,7 @@ def land_on_elevated_surface():
             #fly onto a landing platform at non-zero height (ex: from floor to desk, etc)
             pc.forward(1.0)
             pc.left(1.0)
-            # land() will be called on context exit, gradually lowering to the default_lanidng_height, then stoppig motors
+            # land() will be called on context exit, gradually lowering to default_lanidng_height, then stoppig motors
 
 
 def simple_sequence():

--- a/examples/position_commander_demo.py
+++ b/examples/position_commander_demo.py
@@ -67,6 +67,15 @@ def slightly_more_complex_usage():
             pc.go_to(0.0, 0.0)
 
 
+def land_on_elevated_surface():
+    with SyncCrazyflie(uri, cf=Crazyflie(rw_cache='./cache')) as scf:
+        with PositionHlCommander(scf, default_height=0.5, default_velocity=0.2, default_landing_height=0.35) as pc:
+            #fly onto a landing platform at non-zero height (ex: from floor to desk, etc)
+            pc.forward(1.0)
+            pc.left(1.0)
+            # land() will be called on context exit, gradually lowering to the default_lanidng_height, then stoppig motors
+
+
 def simple_sequence():
     with SyncCrazyflie(uri, cf=Crazyflie(rw_cache='./cache')) as scf:
         with PositionHlCommander(scf) as pc:
@@ -81,3 +90,4 @@ if __name__ == '__main__':
 
     simple_sequence()
     # slightly_more_complex_usage()
+    # land_on_elevated_surface()

--- a/test/positioning/test_position_hl_commander.py
+++ b/test/positioning/test_position_hl_commander.py
@@ -135,7 +135,7 @@ class TestPositionHlCommander(unittest.TestCase):
         self.sut.set_landing_height(0.4)
 
         # Test
-        self.sut.land(velocity=0.6, landing_height=0.4)
+        self.sut.land(velocity=0.6)
 
         # Assert
         duration = (1.0 - 0.4) / 0.6

--- a/test/positioning/test_position_hl_commander.py
+++ b/test/positioning/test_position_hl_commander.py
@@ -128,6 +128,20 @@ class TestPositionHlCommander(unittest.TestCase):
         self.commander_mock.land.assert_called_with(0.0, duration)
         sleep_mock.assert_called_with(duration)
 
+    def test_that_it_goes_down_to_set_landing_height_on_landing(
+            self, sleep_mock):
+        # Fixture
+        self.sut.take_off(height=1.0)
+        self.sut.set_landing_height(0.4)
+
+        # Test
+        self.sut.land(velocity=0.6, landing_height=0.4)
+
+        # Assert
+        duration = (1.0 - 0.4) / 0.6
+        self.commander_mock.land.assert_called_with(0.4, duration)
+        sleep_mock.assert_called_with(duration)
+
     def test_that_it_takes_off_and_lands_as_context_manager(
             self, sleep_mock):
         # Fixture


### PR DESCRIPTION
We have encountered a need to land on objects (landing pads) that are situated at a different height than the takeoff (or, more specifically, calibration) height. The function `land()` in `crazyflie.HighLevelCommander` class accepts an `absolute_height_m` parameter, which is hard-coded to zero in `positioning.PositionHlCommander` class's version of this function (which is a pass-through function to the former one). This PR adds an optional parameter to the latter function, as well as introduces a method of specifying a `default_landing_height` at either initialization (`__init__` function), with default of 0.0, or as a separate function call to a newly introduced `set_landing_height` function. A very simple usage example was also added to `position_commander_demo.py` 

We find this functionality a useful addition, with no breaking changes to existing code. 

Unit test `test_that_it_goes_down_to_set_landing_height_on_landing` added; physically tested on Crazyflie 2.1 with Lighthouse deck.
