### PR TITLE
Make USB permission easier to add on Linux

### DIFF
--- a/docs/installation/usb_permissions.md
+++ b/docs/installation/usb_permissions.md
@@ -5,7 +5,7 @@ page_id: usd_permissions
 
 ### Linux
 
-The following steps make it possible to use the USB Radio without being root.
+The following steps make it possible to use the USB Radio and Crazyflie 2 over USB without being root.
 
 ```
 sudo groupadd plugdev
@@ -14,18 +14,16 @@ sudo usermod -a -G plugdev $USER
 
 You will need to log out and log in again in order to be a member of the plugdev group.
 
-Create a file named ```/etc/udev/rules.d/99-crazyradio.rules``` and add the
-following:
+Copy-paste the following in your console, this will create the file ```/etc/udev/rules.d/99-bitcraze.rules```:
 ```
+cat <<EOF | sudo tee /etc/udev/rules.d/99-bitcraze.rules > /dev/null
 # Crazyradio (normal operation)
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="7777", MODE="0664", GROUP="plugdev"
 # Bootloader
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="0101", MODE="0664", GROUP="plugdev"
-```
-
-To connect Crazyflie 2.0 via usb, create a file name ```/etc/udev/rules.d/99-crazyflie.rules``` and add the following:
-```
+# Crazyflie (over USB)
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE="0664", GROUP="plugdev"
+EOF
 ```
 
 You can reload the udev-rules using the following:


### PR DESCRIPTION
Use cat and tee to make a block that can be copy-pasted in a console. It makes it easier to add the required udev rules file.