### PR TITLE
Generate python documentation using pdoc3

### DIFF
--- a/cflib/__init__.py
+++ b/cflib/__init__.py
@@ -56,3 +56,6 @@ cf.open_link("radio://0/125")
 cf.close_link()
 ```
 """
+__pdoc__ = {}
+__pdoc__['cflib.localization'] = False
+__pdoc__['cflib.crtp.cflinkcppdriver'] = False

--- a/docs/_data/menu.yml
+++ b/docs/_data/menu.yml
@@ -13,6 +13,7 @@
     - {page_id: crazyradio_lib}
 - title: Development
   subs:
+    - {page_id: api_reference}
     - {page_id: matlab}
     - {page_id: eeprom}
     - {page_id: uart_communication}

--- a/docs/api/cflib/index.md
+++ b/docs/api/cflib/index.md
@@ -1,0 +1,10 @@
+---
+title: API reference for CFLib
+page_id: api_reference
+---
+
+This is a placeholder, you need to run:
+
+```
+$ ./tools/build-docs/build-docs
+```

--- a/docs/api/template/text.mako
+++ b/docs/api/template/text.mako
@@ -24,10 +24,56 @@
 %>
 
 <%!
+    import re
     def deflist(s):
+        param_re = r':param (.*):'
+        params_found = False
+        in_param = False
+        desc = str()
+
+        #
+        # Here we try to turn the docstring parameters into a markdown table
+        #
+        # :param param1: description1
+        # :param param2: desccription2
+        #                description2 continues
+        # :param param3:
+        #
+        # into:
+        #
+        # #### Parameters
+        #
+        # | Name   | Description |
+        # | ----   | ----------- |
+        # | param1 | decription1 |
+        # | param2 | description2 description2 continues |
+        # | param3 | |
+        #
         out = str()
         for line in s.splitlines():
-            out += line + '\n'
+            match = re.match(param_re, line)
+            if match is not None:
+                if not params_found:
+                    params_found = True
+                    out += h(4, 'Parameters') + '\n'
+                    out += '\n' + '| Name | Description |' + '\n'
+                    out +=        '| ---- | ----------- |' + '\n'
+
+                if in_param:
+                    out += f'{desc} |' + '\n'
+
+                in_param = True
+                out += f'| {match.group(1)} | '
+                desc = line.replace(match.group(0), '')
+
+            elif in_param:
+                desc += line
+            else:
+                out += line + '\n'
+
+        if in_param:
+            out += f'{desc} |' + '\n'
+
         return out
 %>
 

--- a/docs/api/template/text.mako
+++ b/docs/api/template/text.mako
@@ -5,7 +5,7 @@
         if name == 'cflib':
             return 'The CFLib API reference'
         else:
-            return heading + ' ' + name
+            return name.split('.')[-1]
 %>
 
 <%!

--- a/docs/api/template/text.mako
+++ b/docs/api/template/text.mako
@@ -1,0 +1,175 @@
+## Define mini-templates for each portion of the doco.
+
+<%!
+    def title(heading, name):
+        if name == 'cflib':
+            return 'The CFLib API reference'
+        else:
+            return heading + ' ' + name
+%>
+
+<%!
+    def page_id(name):
+        if name == 'cflib':
+            return 'api_reference'
+        else:
+            return name.replace('.', '-')
+%>
+
+<%!
+    from pathlib import Path
+    def linkify(name, module, base_module):
+        link = module.url(relative_to=base_module).replace('html', 'md')
+        return f'[{name}]({link})'
+%>
+
+<%!
+    def deflist(s):
+        out = str()
+        for line in s.splitlines():
+            out += line + '\n'
+        return out
+%>
+
+<%!
+    def h(level, s):
+        return '#' * level + ' ' + s
+%>
+
+<%def name="function(func)" buffered="True">
+    <%
+        returns = show_type_annotations and func.return_annotation() or ''
+        if returns:
+            returns = ' \N{non-breaking hyphen}> ' + returns
+    %>
+```python
+def ${func.name}(${", ".join(func.params(annotate=show_type_annotations))})${returns}
+```
+${func.docstring | deflist}
+---
+</%def>
+
+<%def name="variable(var)" buffered="True">
+    <%
+        annot = show_type_annotations and var.type_annotation() or ''
+        if annot:
+            annot = ': ' + annot
+    %>
+```python
+${var.name}${annot}
+```
+${var.docstring | deflist}
+---
+</%def>
+
+<%def name="class_(cls)" buffered="True">
+${h(4, cls.name)}
+```python
+${cls.name}(${", ".join(cls.params(annotate=show_type_annotations))})
+```
+${cls.docstring | deflist}
+---
+
+<%
+  class_vars = cls.class_variables(show_inherited_members, sort=sort_identifiers)
+  static_methods = cls.functions(show_inherited_members, sort=sort_identifiers)
+  inst_vars = cls.instance_variables(show_inherited_members, sort=sort_identifiers)
+  methods = cls.methods(show_inherited_members, sort=sort_identifiers)
+  mro = cls.mro()
+  subclasses = cls.subclasses()
+%>
+% if mro:
+${h(3, 'Ancestors (in MRO)')}
+    % for c in mro:
+* ${linkify(c.refname, c, module)}
+    % endfor
+
+% endif
+% if subclasses:
+${h(3, 'Descendants')}
+    % for c in subclasses:
+* ${linkify(c.refname, c, module)}
+    % endfor
+
+% endif
+% if class_vars:
+${h(3, 'Class variables')}
+    % for v in class_vars:
+${variable(v)}
+
+    % endfor
+% endif
+% if static_methods:
+${h(3, 'Static methods')}
+    % for f in static_methods:
+${function(f)}
+
+    % endfor
+% endif
+% if inst_vars:
+${h(3, 'Instance variables')}
+    % for v in inst_vars:
+${variable(v)}
+
+    % endfor
+% endif
+% if methods:
+${h(3, 'Methods')}
+    % for m in methods:
+${function(m)}
+
+    % endfor
+% endif
+</%def>
+
+## Start the output logic for an entire module.
+
+<%
+  variables = module.variables(sort=sort_identifiers)
+  classes = module.classes(sort=sort_identifiers)
+  functions = module.functions(sort=sort_identifiers)
+  submodules = module.submodules()
+  heading = 'Namespace' if module.is_namespace else 'Module'
+%>
+
+---
+title: ${title(heading, module.name)}
+page_id: ${page_id(module.name)}
+---
+${deflist(module.docstring)}
+---
+
+% if submodules:
+Sub-modules
+-----------
+    % for m in submodules:
+* ${linkify(m.name, m, module)}
+    % endfor
+% endif
+
+% if variables:
+Variables
+---------
+    % for v in variables:
+${variable(v)}
+
+    % endfor
+% endif
+
+% if functions:
+Functions
+---------
+    % for f in functions:
+${function(f)}
+
+    % endfor
+% endif
+
+% if classes:
+Classes
+-------
+    % for c in classes:
+${class_(c)}
+
+    % endfor
+% endif

--- a/module.json
+++ b/module.json
@@ -1,4 +1,7 @@
 {
   "version": "1.0",
-  "environmentReq": ["python3"]
+  "environmentReq": {
+    "build": ["python3"],
+    "build-docs": ["doxygen"]
+  }
 }

--- a/tools/build-docs/build-docs
+++ b/tools/build-docs/build-docs
@@ -11,4 +11,17 @@ mkdir -p $scriptDir/tmp
 [ -n "$API_REF_BASE" ] || {
     export API_REF_BASE=$(readlink -fn $apiRefDir)
 }
+
+#
+# If cflib is not installed (mostly its dependencies) then pdoc3 cannot
+# traverse the library and get docstrings.
+#
+# The rewriting of HOME is a hack to make this work in a bare-bone Docker
+# environment.
+#
+pip3 show cflib > /dev/null 2>&1 || {  # this will run if cflib is not found
+    HOME=$scriptDir pip3 install --user --upgrade pip
+    HOME=$scriptDir pip3 install --user -e $scriptDir/../../
+}
+
 pdoc3 --force $cflibDir --output-dir $apiRefDir --template-dir $templateDir

--- a/tools/build-docs/build-docs
+++ b/tools/build-docs/build-docs
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+scriptDir=$(dirname $0)
+cflibDir=$scriptDir/../../cflib
+apiRefDir=$scriptDir/../../docs/api
+templateDir=$apiRefDir/template
+
+mkdir -p $apiRefDir
+mkdir -p $scriptDir/tmp
+
+[ -n "$API_REF_BASE" ] || {
+    export API_REF_BASE=$(readlink -fn $apiRefDir)
+}
+pdoc3 --force $cflibDir --output-dir $apiRefDir --template-dir $templateDir


### PR DESCRIPTION
This commit generates API reference documentation using pdoc3.



The program pdoc3 will traverse the cflib module and generate
documentation based on the template file text.mako that we drop in the
template-dir.

The `text.mako` file is doing all the heavy lifting to create the
markdown we want.

For more information about pdoc3 and the custom template system see:
   https://pdoc3.github.io/pdoc/doc/pdoc/#custom-templates

---

<img src="https://user-images.githubusercontent.com/974401/136556218-6e8d1902-5f14-462e-bb6f-6e211d55c80b.png" width="600" style="border:5px solid black" />

---

<img src="https://user-images.githubusercontent.com/974401/136556226-1cfa5110-a156-4f6f-8218-bc54f22ebd52.png" width="600" style="border:5px solid black" />