### PR TITLE
swarm: Handle having scalar values in args dict

### DIFF
--- a/cflib/crazyflie/swarm.py
+++ b/cflib/crazyflie/swarm.py
@@ -278,7 +278,7 @@ class Swarm:
         args = [scf]
 
         if args_dict:
-            args += args_dict[uri]
+            args.append(args_dict[uri])
 
         return args
 


### PR DESCRIPTION
This makes it possible to have non-arrays as argument to swarm
functions.
