### PR TITLE
toc: Fix TocFetcher requesting ToC entries when none are available

### DIFF
--- a/cflib/crazyflie/toc.py
+++ b/cflib/crazyflie/toc.py
@@ -177,7 +177,12 @@ class TocFetcher:
             else:
                 self.state = GET_TOC_ELEMENT
                 self.requested_index = 0
-                self._request_toc_element(self.requested_index)
+                if (self.nbr_of_items > 0):
+                    self._request_toc_element(self.requested_index)
+                else:
+                    logger.debug('No TOC entries for port [%s]' % self.port)
+                    self._toc_cache.insert(self._crc, self.toc.toc)
+                    self._toc_fetch_finished()
 
         elif (self.state == GET_TOC_ELEMENT):
             # Always add new element, but only request new if it's not the


### PR DESCRIPTION
I noticed that the lib requests ToC entries from the Crazyflie when the latter returns that there are none. This should fix it without breaking the existing log messages.
