### PR TITLE
Use include functionality for generated docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,12 @@ venv*
 #jekyll generated pages
 docs/.jekyll-metadata
 docs/api/cflib/*
-tools/build-docs/.local/*
-docs/api/cflib/index.md
+
+# Generated documentation
+tools/build-docs/.local
+tools/build-docs/.cache
+docs/api/cflib
+!docs/api/cflib/index.md
 
 #vscode config folder
 .vscode/

--- a/docs/api/cflib/index.md
+++ b/docs/api/cflib/index.md
@@ -3,8 +3,4 @@ title: API reference for CFLib
 page_id: api_reference
 ---
 
-This is a placeholder, you need to run:
-
-```
-$ ./tools/build-docs/build-docs
-```
+{% include_relative_generated index.md_raw info="Placeholder for generated file. Run `tb build-docs` to generate content." %}

--- a/docs/api/template/text.mako
+++ b/docs/api/template/text.mako
@@ -2,18 +2,12 @@
 
 <%!
     def title(heading, name):
-        if name == 'cflib':
-            return 'The CFLib API reference'
-        else:
-            return name.split('.')[-1]
+        return name.split('.')[-1]
 %>
 
 <%!
     def page_id(name):
-        if name == 'cflib':
-            return 'api_reference'
-        else:
-            return name.replace('.', '-')
+        return name.replace('.', '-')
 %>
 
 <%!

--- a/tools/build-docs/build-docs
+++ b/tools/build-docs/build-docs
@@ -4,12 +4,13 @@ scriptDir=$(dirname $0)
 cflibDir=$scriptDir/../../cflib
 apiRefDir=$scriptDir/../../docs/api
 templateDir=$apiRefDir/template
+tempDir=$scriptDir/.tmp
 
 mkdir -p $apiRefDir
-mkdir -p $scriptDir/tmp
+mkdir -p $tempDir
 
 [ -n "$API_REF_BASE" ] || {
-    export API_REF_BASE=$(readlink -fn $apiRefDir)
+    export API_REF_BASE=$(readlink -fn $tempDir)
 }
 
 #
@@ -24,4 +25,20 @@ pip3 show cflib > /dev/null 2>&1 || {  # this will run if cflib is not found
     HOME=$scriptDir pip3 install --user -e $scriptDir/../../
 }
 
-pdoc3 --force $cflibDir --output-dir $apiRefDir --template-dir $templateDir
+# Generate documentation
+pdoc3 --force $cflibDir --output-dir $tempDir --template-dir $templateDir
+
+# Modify the generated content to fit our file tree
+## Rename root file that will be included in another md file
+rootFile=$tempDir/cflib/index.md_raw
+mv $tempDir/cflib/index.md $rootFile
+## Remove the front matter at the top
+sed -i '1,4d' $rootFile
+## Links are not processed properly in the included content. Hack it by removing index.md
+sed -i s/index\.md// $rootFile
+
+# Copy to the md file tree
+cp -r $tempDir/cflib/* $apiRefDir/cflib/.
+
+# Clean up
+rm -r $tempDir


### PR DESCRIPTION
A new liquid tag has been added to include md files in md files. Use the new tag to include the generated documentation in the root file to avoid overwriting it and making git think it has been modified.