### PR TITLE
Add initial persistent parameter API

### DIFF
--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -437,9 +437,11 @@ class Param():
 
                 is_stored = pk.data[3] == 1
                 if not is_stored:
-                    default_value = struct.unpack(f'<{element.pytype}')
+                    default_value, = struct.unpack(element.pytype, pk.data[4:])
                 else:
-                    default_value, stored_value = struct.unpack(f'<{element.pytype}*2')
+                    # Remove little-endian indicator ('<')
+                    just_type = element.pytype[1:]
+                    default_value, stored_value = struct.unpack(f'<{just_type * 2}', pk.data[4:])
 
                 callback(complete_name,
                          PersistentParamState(

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -446,7 +446,7 @@ class Param():
                 else:
                     # Remove little-endian indicator ('<')
                     just_type = element.pytype[1:]
-                    stored_value, default_value = struct.unpack(f'<{just_type * 2}', pk.data[4:])
+                    default_value, stored_value = struct.unpack(f'<{just_type * 2}', pk.data[4:])
 
                 callback(complete_name,
                          PersistentParamState(

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -68,6 +68,7 @@ MISC_GET_EXTENDED_TYPE = 2
 
 PersistentParamState = namedtuple('PersistentParamState', 'is_stored default_value stored_value')
 
+MISC_PERSISTENT_STORE = 3
 MISC_PERSISTENT_GET_STATE = 4
 
 # One element entry in the TOC
@@ -358,6 +359,30 @@ class Param():
 
         [group, name] = complete_name.split('.')
         return self.values[group][name]
+
+    def persistent_store(self, complete_name, callback=None):
+        """
+        Store the current value of the specified persistent parameter to
+        eeprom. The supplied callback will be called with `True` as an
+        argument on success, and with `False` as an argument on failure.
+
+        @param complete_name The 'group.name' name of the parameter to store
+        @param callback Optional callback should take boolean status as arg
+        """
+        element = self.toc.get_element_by_complete_name(complete_name)
+
+        def new_packet_cb(pk):
+            if pk.channel == MISC_CHANNEL and pk.data[0] == MISC_PERSISTENT_STORE:
+                callback(pk.data[3] == 0)
+                self.cf.remove_port_callback(CRTPPort.PARAM, new_packet_cb)
+
+        if callback is not None:
+            self.cf.add_port_callback(CRTPPort.PARAM, new_packet_cb)
+
+        pk = CRTPPacket()
+        pk.set_header(CRTPPort.PARAM, MISC_CHANNEL)
+        pk.data = struct.pack('<BH', MISC_PERSISTENT_STORE, element.ident)
+        self.cf.send_packet(pk, expected_reply=(tuple(pk.data[:3])))
 
     def persistent_get_state(self, complete_name, callback):
         """

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -371,6 +371,8 @@ class Param():
         @param callback Optional callback should take `complete_name` and boolean status as arguments
         """
         element = self.toc.get_element_by_complete_name(complete_name)
+        if not element.is_persistent():
+            raise AttributeError(f"Param '{complete_name}' is not persistent")
 
         def new_packet_cb(pk):
             if pk.channel == MISC_CHANNEL and pk.data[0] == MISC_PERSISTENT_CLEAR:
@@ -395,6 +397,8 @@ class Param():
         @param callback Optional callback should take `complete_name` and boolean status as arguments
         """
         element = self.toc.get_element_by_complete_name(complete_name)
+        if not element.is_persistent():
+            raise AttributeError(f"Param '{complete_name}' is not persistent")
 
         def new_packet_cb(pk):
             if pk.channel == MISC_CHANNEL and pk.data[0] == MISC_PERSISTENT_STORE:
@@ -427,6 +431,8 @@ class Param():
         @param callback Callback, takes `complete_name` and PersistentParamState namedtuple as arg
         """
         element = self.toc.get_element_by_complete_name(complete_name)
+        if not element.is_persistent():
+            raise AttributeError(f"Param '{complete_name}' is not persistent")
 
         def new_packet_cb(pk):
             if pk.channel == MISC_CHANNEL and pk.data[0] == MISC_PERSISTENT_GET_STATE:

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -570,12 +570,10 @@ class _ParamUpdater(Thread):
         the Crazyflie it will answer with the update param value. """
         self.request_queue.put(pk)
 
-
     def send_param_misc(self, pk):
         """Place a param misc request on the queue. When this is sent to
         the Crazyflie it will answer with the same var_id and command. """
         self.request_queue.put(pk)
-
 
     def _new_packet_cb(self, pk):
         """Callback for newly arrived packets"""

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -441,13 +441,13 @@ class Param():
                 else:
                     # Remove little-endian indicator ('<')
                     just_type = element.pytype[1:]
-                    default_value, stored_value = struct.unpack(f'<{just_type * 2}', pk.data[4:])
+                    stored_value, default_value = struct.unpack(f'<{just_type * 2}', pk.data[4:])
 
                 callback(complete_name,
                          PersistentParamState(
                              is_stored,
                              default_value,
-                             None if not is_stored else stored_value
+                             stored_value if is_stored else None
                          )
                          )
                 self.cf.remove_port_callback(CRTPPort.PARAM, new_packet_cb)

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -443,11 +443,11 @@ class Param():
 
                 callback(complete_name,
                          PersistentParamState(
-                            is_stored,
-                            default_value,
-                            None if not is_stored else stored_value
+                             is_stored,
+                             default_value,
+                             None if not is_stored else stored_value
                          )
-                )
+                         )
                 self.cf.remove_port_callback(CRTPPort.PARAM, new_packet_cb)
 
         self.cf.add_port_callback(CRTPPort.PARAM, new_packet_cb)

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -158,9 +158,6 @@ class Param():
             self.cf, self._useV2, self._param_updated)
         self.param_updater.start()
 
-        self.extended_type_fetcher = _ExtendedTypeFetcher(self.cf, self.toc)
-        self.extended_type_fetcher.start()
-
         self.cf.disconnected.add_callback(self._disconnected)
 
         self.all_updated = Caller()
@@ -270,8 +267,10 @@ class Param():
                         extended_elements.append(element)
 
             if len(extended_elements) > 0:
-                self.extended_type_fetcher.set_callback(refresh_done_callback)
-                self.extended_type_fetcher.request_extended_types(extended_elements)
+                extended_type_fetcher = _ExtendedTypeFetcher(self.cf, self.toc)
+                extended_type_fetcher.start()
+                extended_type_fetcher.set_callback(refresh_done_callback)
+                extended_type_fetcher.request_extended_types(extended_elements)
             else:
                 refresh_done_callback()
 

--- a/cflib/crazyflie/toccache.py
+++ b/cflib/crazyflie/toccache.py
@@ -126,7 +126,7 @@ class TocCache():
             elem.ctype = str(obj['ctype'])
             elem.pytype = str(obj['pytype'])
             elem.access = obj['access']
-            if isinstance(obj, ParamTocElement):
+            if isinstance(elem, ParamTocElement):
                 elem.extended = obj['extended']
             return elem
         return obj

--- a/cflib/crazyflie/toccache.py
+++ b/cflib/crazyflie/toccache.py
@@ -100,13 +100,20 @@ class TocCache():
 
     def _encoder(self, obj):
         """ Encode a toc element leaf-node """
-        return {'__class__': obj.__class__.__name__,
-                'ident': obj.ident,
-                'group': obj.group,
-                'name': obj.name,
-                'ctype': obj.ctype,
-                'pytype': obj.pytype,
-                'access': obj.access}
+        encoded = {
+            '__class__': obj.__class__.__name__,
+            'ident': obj.ident,
+            'group': obj.group,
+            'name': obj.name,
+            'ctype': obj.ctype,
+            'pytype': obj.pytype,
+            'access': obj.access,
+        }
+
+        if isinstance(obj, ParamTocElement):
+            encoded['extended'] = obj.extended
+
+        return encoded
         raise TypeError(repr(obj) + ' is not JSON serializable')
 
     def _decoder(self, obj):
@@ -119,5 +126,7 @@ class TocCache():
             elem.ctype = str(obj['ctype'])
             elem.pytype = str(obj['pytype'])
             elem.access = obj['access']
+            if isinstance(obj, ParamTocElement):
+                elem.extended = obj['extended']
             return elem
         return obj

--- a/examples/parameters/persistent_params.py
+++ b/examples/parameters/persistent_params.py
@@ -30,13 +30,13 @@ Note: this script will change the value of the LED ring.effect parameter
 """
 import logging
 import sys
+import time
 from threading import Event
 
 import cflib.crtp
 from cflib.crazyflie import Crazyflie
 from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
 from cflib.utils import uri_helper
-import time
 
 # uri = uri_helper.uri_from_env(default='usb://0')
 uri = uri_helper.uri_from_env(default='radio://0/30/2M/E7E7E7E7E7')
@@ -94,8 +94,6 @@ def get_all_persistent_param_names(cf):
 
     return persistent_params
 
-def all_params_are_fetched():
-    print("Got all!")
 
 if __name__ == '__main__':
     # Initialize the low-level drivers
@@ -133,15 +131,15 @@ if __name__ == '__main__':
         time.sleep(0.1)
 
         print()
-        print("Store the new value in persistent memory")
+        print('Store the new value in persistent memory')
         persist_parameter(scf.cf, param_name)
 
-        print("The new state is:")
+        print('The new state is:')
         get_persistent_state(scf.cf, param_name)
 
         print()
-        print("Clear the persisted parameter")
+        print('Clear the persisted parameter')
         clear_persistent_parameter(scf.cf, param_name)
 
-        print("The new state is:")
+        print('The new state is:')
         get_persistent_state(scf.cf, param_name)

--- a/examples/parameters/persistent_params.py
+++ b/examples/parameters/persistent_params.py
@@ -101,13 +101,7 @@ if __name__ == '__main__':
 
     cf = Crazyflie(rw_cache='./cache')
 
-    fetch_all_params = Event()
-    cf.param.all_updated.add_callback(lambda: fetch_all_params.set())
-
     with SyncCrazyflie(uri, cf=cf) as scf:
-        # Wait for all parameters to be fetched
-        fetch_all_params.wait()
-
         # Get the names of all parameters that can be persisted
         persistent_params = get_all_persistent_param_names(scf.cf)
 

--- a/examples/parameters/persistent_params.py
+++ b/examples/parameters/persistent_params.py
@@ -30,7 +30,6 @@ Note: this script will change the value of the LED ring.effect parameter
 """
 import logging
 import sys
-import time
 from threading import Event
 
 import cflib.crtp

--- a/examples/parameters/persistent_params.py
+++ b/examples/parameters/persistent_params.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2021 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+Example to show the use of persistent parameters.
+
+All persistent parameters are fectched and the current state is printed out.
+Finallay the LED ring effect is set to a new value and stored.
+
+Note: this script will change the value of the LED ring.effect parameter
+"""
+import logging
+import sys
+from threading import Event
+
+import cflib.crtp
+from cflib.crazyflie import Crazyflie
+from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
+from cflib.utils import uri_helper
+
+
+uri = uri_helper.uri_from_env(default='radio://0/80/2M/E7E7E7E7E7')
+
+# Only output errors from the logging framework
+logging.basicConfig(level=logging.ERROR)
+
+
+if __name__ == '__main__':
+    # Initialize the low-level drivers
+    cflib.crtp.init_drivers()
+
+    cf = Crazyflie(rw_cache='./cache')
+    with SyncCrazyflie(uri, cf=cf) as scf:
+        wait_for_callback_event = Event()
+
+        # Collect the names of all persistent parameters
+        persistent_params = []
+        for group_name, params in scf.cf.param.toc.toc.items():
+            for param_name, element in params.items():
+                if element.is_persistent():
+                    complete_name = group_name + '.' + param_name
+                    persistent_params.append(complete_name)
+
+        if len(persistent_params) == 0:
+            print('No persistent parameters')
+            sys.exit(0)
+
+        # Get state for the persistent parameters
+        print('-- All persistent parameters --')
+
+        def state_callback(complete_name, state):
+            print(complete_name, state)
+
+            persistent_params.pop(0)
+            if len(persistent_params) > 0:
+                scf.cf.param.persistent_get_state(persistent_params[0], state_callback)
+            else:
+                wait_for_callback_event.set()
+
+        wait_for_callback_event.clear()
+        # Request the state for the first parameter. The callback will pop the name from the list
+        # and request the next
+        scf.cf.param.persistent_get_state(persistent_params[0], state_callback)
+        # Wait for all parameters to be done
+        wait_for_callback_event.wait()
+
+        print()
+        print('-- Set the default LED ring effect --')
+        led_ring_param_name = 'ring.effect'
+        scf.cf.param.set_value(led_ring_param_name, 7)
+
+        def is_stored_callback():
+            print('New LED ring effect is persisted')
+            wait_for_callback_event.set()
+
+        wait_for_callback_event.clear()
+        scf.cf.param.persistent_store(led_ring_param_name, callback=is_stored_callback)
+        wait_for_callback_event.wait()

--- a/examples/parameters/persistent_params.py
+++ b/examples/parameters/persistent_params.py
@@ -121,9 +121,6 @@ if __name__ == '__main__':
         print(f'Set parameter {param_name} to {param_value}')
         scf.cf.param.set_value(param_name, param_value)
 
-        # Wait a bit to make sure the parameter has been set
-        time.sleep(0.1)
-
         print()
         print('Store the new value in persistent memory')
         persist_parameter(scf.cf, param_name)


### PR DESCRIPTION
A persistent parameter is one that _can_ be stored to eeprom. The way to do this is to set a value to the parameter, using the regular parameter API, and then use CRTP to tell the firmware to store the value. A value can also be cleared from eeprom using CRTP.

In order to build nice UIs we want to be able to tell whether a persistent parameter is stored or not, and what the default value of the parameter is. This is done by asking the firmware about the state.

Also! Since we are taking the last bit in the parameter type to express that this is a persistent parameter we have now introduced the concept of extended type information. That we also fetch as part of the connection in the Crazyflie class.

Contains the following commit:
- Param: fetch extended types at connection
- Param: add persistent_get_state method
- Param: add persistent_store method
- Param: add persistent_clear method
