### PR TITLE
param: Change order of "all updated" check

### DIFF
--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+# !/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 #     ||          ____  _ __
@@ -45,7 +45,6 @@ from .toc import TocFetcher
 from cflib.crtp.crtpstack import CRTPPacket
 from cflib.crtp.crtpstack import CRTPPort
 from cflib.utils.callbacks import Caller
-
 
 __author__ = 'Bitcraze AB'
 __all__ = ['Param', 'ParamTocElement']
@@ -205,6 +204,13 @@ class Param():
                 self.values[element.group] = {}
             self.values[element.group][element.name] = s
 
+            # Once all the parameters are updated call the
+            # callback for "everything updated"
+            if self._check_if_all_updated() and not self.is_updated:
+                self.is_updated = True
+                self._initialized.set()
+                self.all_updated.call()
+
             logger.debug('Updated parameter [%s]' % complete_name)
             if complete_name in self.param_update_callbacks:
                 self.param_update_callbacks[complete_name].call(
@@ -213,14 +219,6 @@ class Param():
                 self.group_update_callbacks[element.group].call(
                     complete_name, s)
             self.all_update_callback.call(complete_name, s)
-
-            # Once all the parameters are updated call the
-            # callback for "everything updated" (after all the param
-            # updated callbacks)
-            if self._check_if_all_updated() and not self.is_updated:
-                self.is_updated = True
-                self._initialized.set()
-                self.all_updated.call()
         else:
             logger.debug('Variable id [%d] not found in TOC', var_id)
 


### PR DESCRIPTION
If we call all callbacks first we end up with "deadlock" if a callback tries to set parameters, since that waits for self._initialized.
