### PR TITLE
Full lighthouse base station geometry estimation

### DIFF
--- a/cflib/localization/_ippe.py
+++ b/cflib/localization/_ippe.py
@@ -1,0 +1,408 @@
+import numpy as np
+
+# Copyright (c) 2016 The Python Packaging Authority (PyPA)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# This code has been copied from https://github.com/royxue/ippe_py and slightly modified
+# to avoid a dependency to Open CV and to collect all functionality in one file.
+
+# The code uses a coordinate system as defined by Open CV.
+
+# The code is based on the paper
+# @article{ year={2014}, issn={0920-5691}, journal={International Journal of Computer Vision}, volume={109}, number={3}, doi={10.1007/s11263-014-0725-5}, title={Infinitesimal Plane-Based Pose Estimation}, url={http://dx.doi.org/10.1007/s11263-014-0725-5}, publisher={Springer US}, keywords={Plane; Pose; SfM; PnP; Homography}, author={Collins, Toby and Bartoli, Adrien}, pages={252-286}, language={English} }  # noqa
+
+
+def mat_run(U, Q, hEstMethod='DLT'):
+    """
+    The solution to Perspective IPPE with point correspondences computed
+    between points in world coordinates on the plane z=0, and normalised points in the
+    camera's image.
+
+    Parameters
+    ----------
+    U: 2xN or 3xN matrix holding the model points in world coordinates. If U
+        is 2xN then the points are defined in world coordinates on the plane z=0
+
+    Q: 2xN matrix holding the points in the image. These are in normalised
+        pixel coordinates. That is, the effects of the camera's intrinsic matrix
+        and lens distortion are corrected, so that the Q projects with a perfect
+        pinhole model.
+
+    hEstMethod: the homography estimation method, by default Direct Linear Transform is used,
+        from Peter Kovesi's implementation at http://www.csse.uwa.edu.au/~pk.
+
+
+    Return
+    ---------
+    IPPEPoses: A Python dictionary that contains 2 sets of pose solution from IPPE including rotation matrix
+        translation matrix, and reprojection error
+    """
+    if hEstMethod not in ['Harker', 'DLT']:
+        print('hEstMethod Error')
+
+    # Inputs shape checking
+    assert(U.shape[0] == 2 or U.shape[0] == 3)
+    assert(U.shape[1] == Q.shape[1])
+    assert(Q.shape[0] == 2)
+
+    n = U.shape[1]
+    modelDims = U.shape[0]
+
+    Uuncentred = U
+
+    if modelDims == 2:
+        # Zero center the model points
+        # Zero center the model points
+        Pbar = np.vstack((np.mean(U, axis=1, keepdims=True), 0))
+        U[0, :] = U[0, :]-Pbar[0]
+        U[1, :] = U[1, :]-Pbar[1]
+    else:
+        # Rotate the model points onto the plane z=0 and zero center them
+        Pbar = np.mean(U[:1])
+        MCenter = np.eye(4)
+        MCenter[0:3, -1] = -Pbar
+        U_ = MCenter[0:3, :].dot(np.vstack((U, np.ones((1, U.shape[1])))))
+        modelRotation, sigs, _ = np.linalg.svd(U_.dot(U_.T))
+        modelRotation = modelRotation.T
+
+        modelRotation = np.hstack((np.vstack((modelRotation, np.array([0, 0, 0]))), np.array([[0], [0], [0], [1]])))
+        Mcorrective = modelRotation.dot(MCenter)
+        U = Mcorrective[0:2, :].dot(np.vstack((U, np.ones((1, U.shape[1])))))
+
+    # TODO: Add support for Harker function
+    # Compute the model to image homography
+    if hEstMethod == 'DLT':
+        _U = np.vstack((U, np.ones((1, n))))
+        _Q = np.vstack((Q, np.ones((1, n))))
+        H = homography2d(_U, _Q)
+
+    H = H/H[2, 2]
+
+    # Compute the Jacobian J of the homography at (0,0)
+    J = np.zeros((2, 2))
+    J[0, 0] = H[0, 0]-H[2, 0]*H[0, 2]
+    J[0, 1] = H[0, 1]-H[2, 1]*H[0, 2]
+    J[1, 0] = H[1, 0]-H[2, 0]*H[1, 2]
+    J[1, 1] = H[1, 1]-H[2, 1]*H[1, 2]
+
+    # Compute rotate solution
+    v = np.vstack((H[0, 2], H[1, 2]))
+    [R1, R2, _] = IPPE_dec(v, J)
+
+    # compute the translation solution
+    t1_ = estT(R1, U, Q)
+    t2_ = estT(R2, U, Q)
+
+    if modelDims == 2:
+        t1 = np.hstack((R1, t1_)).dot(np.vstack((-Pbar, 1)))
+        t2 = np.hstack((R2, t2_)).dot(np.vstack((-Pbar, 1)))
+    else:
+        M1 = np.hstack((R1, t1_))
+        M1 = np.vstack((M1, np.array([0, 0, 0, 1])))
+        M2 = np.hstack((R2, t2_))
+        M2 = np.vstack((M2, np.array([0, 0, 0, 1])))
+        M1 = M1.dot(Mcorrective)
+        M2 = M2.dot(Mcorrective)
+        R1 = M1[0:3, 0:3]
+        R2 = M2[0:3, 0:3]
+        t1 = M1[0:3, -1]
+        t2 = M2[0:3, -1]
+
+    [reprojErr1, reprojErr2] = computeReprojErrs(R1, R2, t1, t2, Uuncentred, Q)
+
+    if reprojErr1 > reprojErr2:
+        [R1, R2, t1, t2, reprojErr1, reprojErr2] = swapSolutions(R1, R2, t1, t2, reprojErr1, reprojErr2)
+
+    IPPEPoses = {}
+    IPPEPoses['R1'] = R1
+    IPPEPoses['t1'] = t1
+    IPPEPoses['R2'] = R2
+    IPPEPoses['t2'] = t2
+    IPPEPoses['reprojError1'] = reprojErr1
+    IPPEPoses['reprojError2'] = reprojErr2
+
+    return IPPEPoses
+
+
+def computeReprojErrs(R1, R2, t1, t2, U, Q):
+    """
+    Computes the reprojection errors for the two solutions generated by IPPE.
+    """
+
+    # transform model points to camera coordinates and project them onto the image
+    if U.shape[0] == 2:
+        PCam1 = R1[:, 0:2].dot(U)
+        PCam2 = R2[:, 0:2].dot(U[0:2, :])
+    else:
+        PCam1 = R1.dot(U)
+        PCam2 = R2.dot(U)
+
+    PCam1[0, :] = PCam1[0, :] + t1[0]
+    PCam1[1, :] = PCam1[1, :] + t1[1]
+    PCam1[2, :] = PCam1[2, :] + t1[2]
+
+    PCam2[0, :] = PCam2[0, :] + t2[0]
+    PCam2[1, :] = PCam2[1, :] + t2[1]
+    PCam2[2, :] = PCam2[2, :] + t2[2]
+
+    Qest_1 = PCam1/np.vstack((PCam1[2, :], PCam1[2, :], PCam1[2, :]))
+    Qest_2 = PCam2/np.vstack((PCam2[2, :], PCam2[2, :], PCam2[2, :]))
+
+    # Compute reprojection errors:
+    reprojErr1 = np.linalg.norm(Qest_1[0:2, :]-Q)
+    reprojErr2 = np.linalg.norm(Qest_2[0:2, :]-Q)
+
+    return [reprojErr1, reprojErr2]
+
+
+def estT(R, psPlane, Q):
+    """
+    Computes the least squares estimate of translation given the rotation solution.
+    """
+    if psPlane.shape[0] == 2:
+        psPlane = np.vstack((psPlane, np.zeros((1, psPlane.shape[1]))))
+
+    Ps = R.dot(psPlane)
+
+    numPts = psPlane.shape[1]
+    Ax = np.zeros((numPts, 3))
+    bx = np.zeros((numPts, 1))
+
+    Ay = np.zeros((numPts, 3))
+    by = np.zeros((numPts, 1))
+
+    Ax[:, 0] = 1
+    Ax[:, 2] = -Q[0, :]
+    bx[:] = (Q[0, :]*Ps[2, :] - Ps[0, :]).reshape(4, 1)
+
+    Ay[:, 1] = 1
+    Ay[:, 2] = -Q[1, :]
+    by[:] = (Q[1, :]*Ps[2, :] - Ps[1, :]).reshape(4, 1)
+
+    A = np.vstack((Ax, Ay))
+    b = np.vstack((bx, by))
+
+    AtA = A.conj().T.dot(A)
+    Atb = A.conj().T.dot(b)
+
+    Ainv = IPPE_inv33(AtA)
+    t = Ainv.dot(Atb)
+    return t
+
+
+def swapSolutions(R1_, R2_, t1_, t2_, reprojErr1_, reprojErr2_):
+    """
+    Swap the solutions
+    """
+
+    R1 = R2_
+    t1 = t2_
+    reprojErr1 = reprojErr2_
+
+    R2 = R1_
+    t2 = t1_
+    reprojErr2 = reprojErr1_
+
+    return [R1, R2, t1, t2, reprojErr1, reprojErr2]
+
+
+def IPPE_inv33(A):
+    """
+    Computes the inverse of a 3x3 matrix, assuming it is full-rank.
+    """
+    a11 = A[0, 0]
+    a12 = A[0, 1]
+    a13 = A[0, 2]
+
+    a21 = A[1, 0]
+    a22 = A[1, 1]
+    a23 = A[1, 2]
+
+    a31 = A[2, 0]
+    a32 = A[2, 1]
+    a33 = A[2, 2]
+
+    Ainv = np.vstack((np.array([a22*a33 - a23*a32, a13*a32 - a12*a33, a12*a23 - a13*a22]),
+                      np.array([a23*a31 - a21*a33, a11*a33 - a13*a31, a13*a21 - a11*a23]),
+                      np.array([a21*a32 - a22*a31, a12*a31 - a11*a32, a11*a22 - a12*a21])))
+    Ainv = Ainv/(a11*a22*a33 - a11*a23*a32 - a12*a21*a33 + a12*a23*a31 + a13*a21*a32 - a13*a22*a31)
+    return Ainv
+
+
+def IPPE_dec(v, J):
+    """
+    Calculate 2 solutions to rotate from J Jacobian of the model-to-plane homography H
+
+    Parameters
+    ----------
+    v: 2x1 vector holding the point in normalised pixel coordinates which maps by H^-1 to
+        the point (0,0,0) in world coordinates.
+    J: 2x2 Jacobian matrix of H at (0,0).
+
+    Return
+    ---------
+    R1: 3x3 Rotation matrix (first solution)
+    R2: 3x3 Rotation matrix (second solution)
+    gamma: The positive real-valued inverse-scale factor.
+    """
+
+    # Calculate the correction rotation Rv
+    t = np.linalg.norm(v)
+
+    if t < np.finfo(float).eps:
+        # the plane is fronto-parallel to the camera, so set the corrective rotation Rv to identity.
+        # There will be only one solution to pose.
+        Rv = np.eye(3)
+    else:
+        # the plane is not fronto-parallel to the camera, so set the corrective rotation Rv
+        s = np.linalg.norm(np.vstack((v, 1)))
+        costh = 1./s
+        sinth = np.sqrt(1-1./s**2)
+        Kcrs = 1./t*(np.vstack([np.hstack([np.zeros((2, 2)), v]), np.hstack([-v.T, np.zeros((1, 1))])]))
+        Rv = np.eye(3) + sinth*Kcrs + (1.-costh)*Kcrs.dot(Kcrs)
+
+    # Set up 2x2 SVD decomposition
+    B = np.hstack((np.eye(2), -v)).dot(Rv[:, 0:2])
+    dt = B[0, 0]*B[1, 1] - B[0, 1]*B[1, 0]
+    Binv = np.vstack([np.hstack([B[1, 1]/dt, -B[0, 1]/dt]), np.hstack([-B[1, 0]/dt, B[0, 0]/dt])])
+    A = Binv.dot(J)
+
+    # Compute the largest singular value of A
+    AAT = A.dot(A.T)
+    gamma = np.sqrt(1./2*(AAT[0, 0] + AAT[1, 1] + np.sqrt((AAT[0, 0]-AAT[1, 1])**2 + 4*AAT[0, 1]**2)))
+
+    # Reconstruct the full rotation matrices
+    R22_tild = A/gamma
+
+    h = np.eye(2)-R22_tild.T.dot(R22_tild)
+    b = np.vstack((np.sqrt(h[0, 0]), np.sqrt(h[1, 1])))
+    if h[0, 1] < 0:
+        b[1] = -b[1]
+    v1 = np.vstack((R22_tild[:, 0:1], np.array([b[0]])))
+    v2 = np.vstack((R22_tild[:, 1:2], np.array([b[1]])))
+    d = IPPE_crs(v1, v2)
+    c = d[0:2]
+    a = d[2]
+    R1 = Rv.dot(np.vstack((np.hstack((R22_tild, c)), np.hstack((b.conj().T, np.array([a]))))))
+    R2 = Rv.dot(np.vstack((np.hstack((R22_tild, -c)), np.hstack((-b.conj().T, np.array([a]))))))
+
+    return [R1, R2, gamma]
+
+
+def IPPE_crs(v1, v2):
+    """
+    3D cross product for vectors v1 and v2
+    """
+    v3 = np.zeros((3, 1))
+    v3[0] = v1[1]*v2[2]-v1[2]*v2[1]
+    v3[1] = v1[2]*v2[0]-v1[0]*v2[2]
+    v3[2] = v1[0]*v2[1]-v1[1]*v2[0]
+
+    return v3
+
+
+def homography2d(x1, x2):
+    """
+    Direct Linear Transform
+
+    Input:
+    x1: 3xN set of homogeneous points
+    x2: 3xN set of homogeneous points such that x1<->x2
+
+    Returns:
+    H: the 3x3 homography such that x2 = H*x1
+    """
+    [x1, T1] = normalise2dpts(x1)
+    [x2, T2] = normalise2dpts(x2)
+
+    Npts = x1.shape[1]
+
+    A = np.zeros((3*Npts, 9))
+
+    O = np.zeros(3)  # noqa
+
+    for i in range(0, Npts):
+        X = x1[:, i].T
+        x = x2[0, i]
+        y = x2[1, i]
+        w = x2[2, i]
+        A[3*i, :] = np.array([O, -w*X, y*X]).reshape(1, 9)
+        A[3*i+1, :] = np.array([w*X, O, -x*X]).reshape(1, 9)
+        A[3*i+2, :] = np.array([-y*X, x*X, O]).reshape(1, 9)
+
+    [U, D, Vh] = np.linalg.svd(A)
+    V = Vh.T
+
+    H = V[:, 8].reshape(3, 3)
+
+    H = np.linalg.solve(T2, H)
+    H = H.dot(T1)
+
+    return H
+
+
+def normalise2dpts(pts):
+    """
+    Function translates and normalises a set of 2D homogeneous points
+    so that their centroid is at the origin and their mean distance from
+    the origin is sqrt(2).  This process typically improves the
+    conditioning of any equations used to solve homographies, fundamental
+    matrices etc.
+
+
+    Inputs:
+    pts: 3xN array of 2D homogeneous coordinates
+
+    Returns:
+    newpts: 3xN array of transformed 2D homogeneous coordinates.  The
+            scaling parameter is normalised to 1 unless the point is at
+            infinity.
+    T: The 3x3 transformation matrix, newpts = T*pts
+    """
+    if pts.shape[0] != 3:
+        print('Input shoud be 3')
+
+    finiteind = np.nonzero(abs(pts[2, :]) > np.spacing(1))
+
+    # if len(finiteind) != pts.shape[1]:
+    #     print('Some points are at infinity')
+
+    dist = []
+    for i in finiteind:
+        pts[0, i] = pts[0, i]/pts[2, i]
+        pts[1, i] = pts[1, i]/pts[2, i]
+        pts[2, i] = 1
+
+        c = np.mean(pts[0:2, i].T, axis=0).T
+
+        newp1 = pts[0, i]-c[0]
+        newp2 = pts[1, i]-c[1]
+
+        dist.append(np.sqrt(newp1**2 + newp2**2))
+
+    meandist = np.mean(dist[:])
+
+    scale = np.sqrt(2)/meandist
+
+    T = np.array([[scale, 0, -scale*c[0]], [0, scale, -scale*c[1]], [0, 0, 1]])
+
+    newpts = T.dot(pts)
+
+    return [newpts, T]

--- a/cflib/localization/ippe_cf.py
+++ b/cflib/localization/ippe_cf.py
@@ -22,6 +22,7 @@
 from collections import namedtuple
 
 import numpy as np
+import numpy.typing as npt
 
 from ._ippe import mat_run
 
@@ -46,7 +47,7 @@ class IppeCf:
     Solution = namedtuple('Solution', ['R', 't', 'reproj_err'])
 
     @staticmethod
-    def mat_run(U_cf, Q_cf):
+    def solve(U_cf: npt.ArrayLike, Q_cf: npt.ArrayLike) -> list[Solution]:
         """
         The solution to Perspective IPPE with point correspondences computed
         between points in world coordinates on the plane z=0, and normalised points in the

--- a/cflib/localization/ippe_cf.py
+++ b/cflib/localization/ippe_cf.py
@@ -57,24 +57,17 @@ class IppeCf:
 
         This is a wrapper function to convert from/to CF coordinate system/array style
 
-        Parameters
-        ----------
-        U_cf: Nx3 matrix holding the model points in world coordinates.
+        :param U_cf: Nx3 matrix holding the model points in world coordinates.
+        :param Q_cf: Nx2 matrix holding the points in the image. These are in normalised
+                     pixel coordinates. That is, the effects of the camera's intrinsic matrix
+                     and lens distortion are corrected, so that the Q projects with a perfect
+                     pinhole model.
 
-        Q_cf: Nx2 matrix holding the points in the image. These are in normalised
-            pixel coordinates. That is, the effects of the camera's intrinsic matrix
-            and lens distortion are corrected, so that the Q projects with a perfect
-            pinhole model.
-
-            First param: Y (positive to the left)
-            Second param: Z (positive up)
-
-
-        Return
-        ---------
-        IPPEPoses: A list that contains 2 sets of pose solution from IPPE including rotation matrix
-            translation matrix, and reprojection error. The first solution in the list has
-            the smallest reprojection error.
+                     First param: Y (positive to the left)
+                     Second param: Z (positive up)
+        :return: A list that contains 2 sets of pose solution from IPPE including rotation matrix
+                 translation matrix, and reprojection error. The first solution in the list has
+                 the smallest reprojection error.
         """
 
         U, Q = IppeCf._cf_to_ippe(U_cf, Q_cf)

--- a/cflib/localization/ippe_cf.py
+++ b/cflib/localization/ippe_cf.py
@@ -19,6 +19,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
 from collections import namedtuple
 
 import numpy as np

--- a/cflib/localization/ippe_cf.py
+++ b/cflib/localization/ippe_cf.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2022 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+from collections import namedtuple
+
+import numpy as np
+
+from ._ippe import mat_run
+
+
+class IppeCf:
+    """
+    A wrapper class to simplify usage of IPPE in CF code.
+    Converts between CF style of coordinate systems/data structures and
+    IPPE (Open CV) style.
+    """
+
+    # Rotation matrix to transform from IPPE to CF
+    _R_ippe_to_cf = np.array([
+        [0.0, 0.0, 1.0],
+        [-1.0, 0.0, 0.0],
+        [0.0, -1.0, 0.0],
+    ])
+
+    # Rotation matrix to transform from CF to IPPE
+    _R_cf_to_ippe = np.transpose(_R_ippe_to_cf)
+
+    Solution = namedtuple('Solution', ['R', 't', 'reproj_err'])
+
+    @staticmethod
+    def mat_run(U_cf, Q_cf):
+        """
+        The solution to Perspective IPPE with point correspondences computed
+        between points in world coordinates on the plane z=0, and normalised points in the
+        camera's image.
+
+        This is a wrapper function to convert from/to CF coordinate system/array style
+
+        Parameters
+        ----------
+        U_cf: Nx3 matrix holding the model points in world coordinates.
+
+        Q_cf: Nx2 matrix holding the points in the image. These are in normalised
+            pixel coordinates. That is, the effects of the camera's intrinsic matrix
+            and lens distortion are corrected, so that the Q projects with a perfect
+            pinhole model.
+
+            First param: Y (positive to the left)
+            Second param: Z (positive up)
+
+
+        Return
+        ---------
+        IPPEPoses: A list that contains 2 sets of pose solution from IPPE including rotation matrix
+            translation matrix, and reprojection error. The first solution in the list has
+            the smallest reprojection error.
+        """
+
+        U, Q = IppeCf._cf_to_ippe(U_cf, Q_cf)
+        solutions = mat_run(U, Q)
+        return IppeCf._ippe_to_cf(solutions)
+
+    @staticmethod
+    def _cf_to_ippe(U_cf, Q_cf):
+        modelDims = U_cf.shape[0]
+        U_t = np.zeros_like(U_cf, dtype=float)
+        Q_t = np.zeros_like(Q_cf, dtype=float)
+        for i in range(modelDims):
+            U_t[i] = IppeCf._rotate_vector_to_ippe(U_cf[i])
+            Q_t[i] = np.array((-Q_cf[i][0], -Q_cf[i][1]))
+
+        U = np.transpose(U_t)
+        Q = np.transpose(Q_t)
+
+        return U, Q
+
+    @staticmethod
+    def _ippe_to_cf(solutions):
+        result = [
+            IppeCf.Solution(
+                IppeCf._rotate_rot_mat_to_cf(solutions['R1']),
+                IppeCf._rotate_vector_to_cf(solutions['t1']),
+                solutions['reprojError1']
+            ),
+            IppeCf.Solution(
+                IppeCf._rotate_rot_mat_to_cf(solutions['R2']),
+                IppeCf._rotate_vector_to_cf(solutions['t2']),
+                solutions['reprojError2']
+            )
+        ]
+
+        return result
+
+    @staticmethod
+    def _rotate_vector_to_ippe(v):
+        return np.dot(IppeCf._R_cf_to_ippe, v)
+
+    def _rotate_vector_to_cf(v):
+        return np.dot(IppeCf._R_ippe_to_cf, v)
+
+    @staticmethod
+    def _rotate_rot_mat_to_cf(R):
+        return np.dot(IppeCf._R_ippe_to_cf, np.dot(R, IppeCf._R_cf_to_ippe))

--- a/cflib/localization/lighthouse_bs_geo.py
+++ b/cflib/localization/lighthouse_bs_geo.py
@@ -22,6 +22,8 @@
 """
 Functionality to handle base station geometry in the lighthouse poistioning system
 """
+from __future__ import annotations
+
 from cflib.localization.lighthouse_bs_vector import LighthouseBsVector
 from cflib.localization.lighthouse_geometry_solver import LighthouseGeometrySolver
 from cflib.localization.lighthouse_initial_estimator import LighthouseInitialEstimator

--- a/cflib/localization/lighthouse_bs_geo.py
+++ b/cflib/localization/lighthouse_bs_geo.py
@@ -6,7 +6,7 @@
 # | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
 #    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
 #
-# Copyright (C) 2021 Bitcraze AB
+# Copyright (C) 2021-2022 Bitcraze AB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,10 +22,13 @@
 """
 Functionality to handle base station geometry in the lighthouse poistioning system
 """
-import math
-
-import cv2 as cv
-import numpy as np
+from cflib.localization.lighthouse_bs_vector import LighthouseBsVector
+from cflib.localization.lighthouse_bs_vector import LighthouseBsVectors
+from cflib.localization.lighthouse_geometry_solver import LighthouseGeometrySolver
+from cflib.localization.lighthouse_initial_estimator import LighthouseInitialEstimator
+from cflib.localization.lighthouse_sample_matcher import LighthouseSampleMatcher
+from cflib.localization.lighthouse_types import LhDeck4SensorPositions
+from cflib.localization.lighthouse_types import LhMeasurement
 
 
 class LighthouseBsGeoEstimator:
@@ -35,48 +38,10 @@ class LighthouseBsGeoEstimator:
     """
 
     def __init__(self):
-        self._directions = {
-            self._hash_sensor_order([2, 0, 1, 3]): math.radians(0),
-            self._hash_sensor_order([2, 0, 3, 1]): math.radians(25),
-            self._hash_sensor_order([2, 3, 0, 1]): math.radians(65),
-            self._hash_sensor_order([3, 2, 0, 1]): math.radians(90),
-            self._hash_sensor_order([3, 2, 1, 0]): math.radians(115),
-            self._hash_sensor_order([3, 1, 2, 0]): math.radians(155),
-            self._hash_sensor_order([1, 3, 2, 0]): math.radians(180),
-            self._hash_sensor_order([1, 3, 0, 2]): math.radians(205),
-            self._hash_sensor_order([1, 0, 3, 2]): math.radians(245),
-            self._hash_sensor_order([0, 1, 3, 2]): math.radians(270),
-            self._hash_sensor_order([0, 1, 2, 3]): math.radians(295),
-            self._hash_sensor_order([0, 2, 1, 3]): math.radians(335),
-        }
-
-        # Sensor distances on the lighthouse deck
-        sensor_distance_width = 0.015
-        sensor_distance_length = 0.03
-
-        # Sensor positions in world coordinates, open cv style
-        self._lighthouse_3d = np.float32(
-            [
-                [-sensor_distance_width / 2, 0, -sensor_distance_length / 2],
-                [sensor_distance_width / 2, 0, -sensor_distance_length / 2],
-                [-sensor_distance_width / 2, 0, sensor_distance_length / 2],
-                [sensor_distance_width / 2, 0, sensor_distance_length / 2]
-            ])
-
-        # Camera matrix
-        self._K = np.float64(
-            [
-                [1.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0],
-                [0.0, 0.0, 1.0]
-            ])
-
-        self._dist_coef = np.zeros(4)
-
         # Sanity check maximum pos
-        self._sanity_max_pos = 10
+        self._sanity_max_pos = 15
 
-    def estimate_geometry(self, bs_vectors):
+    def estimate_geometry(self, bs_vectors: list[LighthouseBsVector]):
         """
         Estimate the full pose of a base station based on angles from the 4 sensors
         on a lighthouse deck. The result is a rotation matrix and position of the
@@ -86,11 +51,15 @@ class LighthouseBsGeoEstimator:
         :return rot_bs_in_cf_coord: Rotation matrix of the BS in the CFs coordinate system
         :return pos_bs_in_cf_coord: Position vector of the BS in the CFs coordinate system
         """
-        guess_yaw = self._find_initial_yaw_guess(bs_vectors)
-        rvec_guess, tvec_guess = self._convert_yaw_to_open_cv(guess_yaw)
-        rw_ocv, tw_ocv = self._estimate_pose_by_pnp(bs_vectors, rvec_guess, tvec_guess)
-        rot_bs_in_cf_coord, pos_bs_in_cf_coord = self._opencv_to_cf(rw_ocv, tw_ocv)
-        return rot_bs_in_cf_coord, pos_bs_in_cf_coord
+        bs_id = 0
+
+        samples = [LhMeasurement(timestamp=0.0, base_station_id=bs_id, angles=LighthouseBsVectors(bs_vectors))]
+        matched_samples = LighthouseSampleMatcher.match(samples)
+        initial_guess = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
+        solution = LighthouseGeometrySolver.solve(initial_guess, matched_samples, LhDeck4SensorPositions.positions)
+        pose = solution.bs_poses[bs_id]
+
+        return pose.rot_matrix, pose.translation
 
     def sanity_check_result(self, pos_bs_in_cf_coord):
         """
@@ -101,111 +70,3 @@ class LighthouseBsGeoEstimator:
             if (abs(coord) > self._sanity_max_pos):
                 return False
         return True
-
-    def _find_initial_yaw_guess(self, bs_vectors):
-        # Assume bs is faicing slighly downwards and fairly horizontal
-        # Sort sensors in the order they are hit by the horizontal sweep
-        # and use the order to figure out roughly the direction to the
-        # base station
-        sweeps_x = {
-            0: bs_vectors[0].lh_v1_horiz_angle,
-            1: bs_vectors[1].lh_v1_horiz_angle,
-            2: bs_vectors[2].lh_v1_horiz_angle,
-            3: bs_vectors[3].lh_v1_horiz_angle
-        }
-
-        ordered_map = {k: v for k, v in sorted(sweeps_x.items(), key=lambda item: item[1])}
-        sensor_order = list(ordered_map.keys())
-
-        # The base station is roughly in this direction, in CF (world) coordinates
-        return self._directions[self._hash_sensor_order(sensor_order)]
-
-    def _hash_sensor_order(self, order):
-        hash = 0
-        for i in range(4):
-            hash += order[i] * 4 ** i
-        return hash
-
-    def _convert_yaw_to_open_cv(self, yaw):
-        # Base station height
-        bs_h = 2.0
-        # Distance to base station along the floor
-        bs_fd = 3.0
-        # Distance to base station
-        bs_dist = math.sqrt(bs_h ** 2 + bs_fd ** 2)
-        elevation = math.atan2(bs_h, bs_fd)
-
-        # Initial position of the CF in camera coordinate system, open cv style
-        tvec_start = np.array([0, 0, bs_dist])
-
-        # Calculate rotation matrix
-        d_c = math.cos(-yaw + math.pi)
-        d_s = math.sin(-yaw + math.pi)
-        R_rot_y = np.array([
-            [d_c, 0.0, d_s],
-            [0.0, 1.0, 0.0],
-            [-d_s, 0.0, d_c],
-        ])
-
-        e_c = math.cos(elevation)
-        e_s = math.sin(elevation)
-        R_rot_x = np.array([
-            [1.0, 0.0, 0.0],
-            [0.0, e_c, -e_s],
-            [0.0, e_s, e_c],
-        ])
-
-        R = np.dot(R_rot_x, R_rot_y)
-        rvec_start, _ = cv.Rodrigues(R)
-
-        return rvec_start, tvec_start
-
-    def _estimate_pose_by_pnp(self, bs_vectors, rvec_start, tvec_start):
-        # Sensors as seen by the "camera"
-        lighthouse_image_projection = np.float32(
-            [
-                [-math.tan(bs_vectors[0].lh_v1_horiz_angle), -math.tan(bs_vectors[0].lh_v1_vert_angle)],
-                [-math.tan(bs_vectors[1].lh_v1_horiz_angle), -math.tan(bs_vectors[1].lh_v1_vert_angle)],
-                [-math.tan(bs_vectors[2].lh_v1_horiz_angle), -math.tan(bs_vectors[2].lh_v1_vert_angle)],
-                [-math.tan(bs_vectors[3].lh_v1_horiz_angle), -math.tan(bs_vectors[3].lh_v1_vert_angle)]
-            ])
-
-        _ret, rvec_est, tvec_est = cv.solvePnP(
-            self._lighthouse_3d,
-            lighthouse_image_projection,
-            self._K,
-            self._dist_coef,
-            flags=cv.SOLVEPNP_ITERATIVE,
-            rvec=rvec_start,
-            tvec=tvec_start,
-            useExtrinsicGuess=True)
-
-        if not _ret:
-            raise Exception('No solution found')
-
-        Rw_ocv, Tw_ocv = self._cam_to_world(rvec_est, tvec_est)
-        return Rw_ocv, Tw_ocv
-
-    def _cam_to_world(self, rvec_c, tvec_c):
-        R_c, _ = cv.Rodrigues(rvec_c)
-        R_w = np.linalg.inv(R_c)
-        tvec_w = -np.matmul(R_w, tvec_c)
-        return R_w, tvec_w
-
-    def _opencv_to_cf(self, R_cv, t_cv):
-        R_opencv_to_cf = np.array([
-            [0.0, 0.0, 1.0],
-            [-1.0, 0.0, 0.0],
-            [0.0, -1.0, 0.0],
-        ])
-
-        R_cf_to_opencv = np.array([
-            [0.0, -1.0, 0.0],
-            [0.0, 0.0, -1.0],
-            [1.0, 0.0, 0.0],
-        ])
-
-        t_cf = np.dot(R_opencv_to_cf, t_cv)
-        R_cf = np.dot(R_opencv_to_cf, np.dot(R_cv, R_cf_to_opencv))
-
-        return R_cf, t_cf

--- a/cflib/localization/lighthouse_bs_geo.py
+++ b/cflib/localization/lighthouse_bs_geo.py
@@ -23,7 +23,6 @@
 Functionality to handle base station geometry in the lighthouse poistioning system
 """
 from cflib.localization.lighthouse_bs_vector import LighthouseBsVector
-from cflib.localization.lighthouse_bs_vector import LighthouseBsVectors
 from cflib.localization.lighthouse_geometry_solver import LighthouseGeometrySolver
 from cflib.localization.lighthouse_initial_estimator import LighthouseInitialEstimator
 from cflib.localization.lighthouse_sample_matcher import LighthouseSampleMatcher
@@ -53,7 +52,7 @@ class LighthouseBsGeoEstimator:
         """
         bs_id = 0
 
-        samples = [LhMeasurement(timestamp=0.0, base_station_id=bs_id, angles=LighthouseBsVectors(bs_vectors))]
+        samples = [LhMeasurement(timestamp=0.0, base_station_id=bs_id, angles=bs_vectors)]
         matched_samples = LighthouseSampleMatcher.match(samples)
         initial_guess = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
         solution = LighthouseGeometrySolver.solve(initial_guess, matched_samples, LhDeck4SensorPositions.positions)

--- a/cflib/localization/lighthouse_bs_vector.py
+++ b/cflib/localization/lighthouse_bs_vector.py
@@ -142,8 +142,22 @@ class LighthouseBsVector:
 
 class LighthouseBsVectors(list[LighthouseBsVector]):
     def projection_pair_list(self) -> npt.NDArray:
+        """
+        Genereate a list of projection pairs for all vectors
+        """
         result = np.empty((len(self), 2), dtype=float)
         for i, vector in enumerate(self):
             result[i] = vector.projection
+
+        return result
+
+    def angle_list(self) -> npt.NDArray:
+        """
+        Genereate a list of angles for all vectors, the order is horizontal, vertical, horizontal, vertical...
+        """
+        result = np.empty((len(self) * 2), dtype=float)
+        for i, vector in enumerate(self):
+            result[i * 2] = vector.lh_v1_horiz_angle
+            result[i * 2 + 1] = vector.lh_v1_vert_angle
 
         return result

--- a/cflib/localization/lighthouse_bs_vector.py
+++ b/cflib/localization/lighthouse_bs_vector.py
@@ -6,7 +6,7 @@
 # | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
 #    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
 #
-# Copyright (C) 2021 Bitcraze AB
+# Copyright (C) 2021-2022 Bitcraze AB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/cflib/localization/lighthouse_bs_vector.py
+++ b/cflib/localization/lighthouse_bs_vector.py
@@ -22,20 +22,21 @@
 import math
 
 import numpy as np
+import numpy.typing as npt
 
 
 class LighthouseBsVector:
     """
     This class is representing a vector from a base station into space,
     in the base station reference frame. Typically the intersection of
-    two light planes.
+    two light planes defined by angles measured by a base station.
     It also provides functionality to convert between lighthouse V1 angles,
     V2 angles and cartesian coordinates.
     """
 
     T = math.pi / 6
 
-    def __init__(self, lh_v1_horiz_angle, lh_v1_vert_angle):
+    def __init__(self, lh_v1_horiz_angle: float, lh_v1_vert_angle: float) -> None:
         """
         Initialize from lighthouse V1 angles
         :param lh_v1_horiz_angle: Horizontal sweep angle, 0 straight forward. Right (seen from the bs) is negative,
@@ -46,7 +47,7 @@ class LighthouseBsVector:
         self._lh_v1_vert_angle = lh_v1_vert_angle
 
     @classmethod
-    def from_lh2(cls, lh_v2_angle_1, lh_v2_angle_2):
+    def from_lh2(cls, lh_v2_angle_1: float, lh_v2_angle_2: float) -> 'LighthouseBsVector':
         """
         Create a LighthouseBsVector object from lighthouse V2 angles
         :param lh_v2_angle_1: First sweep angles, 0 straight ahead
@@ -60,7 +61,7 @@ class LighthouseBsVector:
         return cls(lh_v1_horiz_angle, lh_v1_vert_angle)
 
     @classmethod
-    def from_cart(cls, cart_vector):
+    def from_cart(cls, cart_vector: list[float]) -> 'LighthouseBsVector':
         """
         Create a LighthouseBsVector object from cartesian coordinates.
         :param cart_vector: (x, y, z) to a point
@@ -70,41 +71,79 @@ class LighthouseBsVector:
 
         return cls(lh_v1_horiz_angle, lh_v1_vert_angle)
 
+    @classmethod
+    def from_projection(cls, proj_point: list[float]) -> 'LighthouseBsVector':
+        """
+        Create a LighthouseBsVector object from the projection point on the plane x=1.0
+        :param projection point: (y, z)
+        """
+        lh_v1_horiz_angle = math.atan(proj_point[0])
+        lh_v1_vert_angle = math.atan(proj_point[1])
+
+        return cls(lh_v1_horiz_angle, lh_v1_vert_angle)
+
     @property
-    def lh_v1_horiz_angle(self):
+    def lh_v1_horiz_angle(self) -> float:
         """
         Lightouse V1 horizontal sweep angle
         """
         return self._lh_v1_horiz_angle
 
     @property
-    def lh_v1_vert_angle(self):
+    def lh_v1_vert_angle(self) -> float:
         """
         Lightouse V1 vertical sweep angle
         """
         return self._lh_v1_vert_angle
 
     @property
-    def lh_v2_angle_1(self):
+    def lh_v1_angle_pair(self) -> tuple[float, float]:
+        """
+        Lightouse V1 angle pair (horiz, vert)
+        """
+        return self._lh_v1_horiz_angle, self._lh_v1_vert_angle,
+
+    @property
+    def lh_v2_angle_1(self) -> float:
         """
         Lightouse V2 first sweep angle
         """
         return self._lh_v1_horiz_angle + math.asin(self._q() * math.tan(-self.T))
 
     @property
-    def lh_v2_angle_2(self):
+    def lh_v2_angle_2(self) -> float:
         """
         Lightouse V2 second sweep angle
         """
         return self._lh_v1_horiz_angle + math.asin(self._q() * math.tan(self.T))
 
     @property
-    def cart(self):
+    def cart(self) -> npt.NDArray[np.float32]:
         """
         A normalized vector in cartesian coordinates
         """
-        v = np.array((1, math.tan(self._lh_v1_horiz_angle), math.tan(self._lh_v1_vert_angle)))
+        v = np.float32((1, math.tan(self._lh_v1_horiz_angle), math.tan(self._lh_v1_vert_angle)))
         return v / np.linalg.norm(v)
+
+    @property
+    def projection(self) -> npt.NDArray[np.float32]:
+        """
+        The 2D point (y, z) when projected on the plane x=1.0 (one meter in front of the base station)
+        """
+        return np.float32((math.tan(self._lh_v1_horiz_angle), math.tan(self._lh_v1_vert_angle)))
 
     def _q(self):
         return math.tan(self._lh_v1_vert_angle) / math.sqrt(1 + math.tan(self._lh_v1_horiz_angle) ** 2)
+
+
+# A LighthouseBsVectors is a list of 4 LighthouseBsVector, one for
+# each sensor
+# LighthouseBsVectors = list[LighthouseBsVector]
+
+class LighthouseBsVectors(list[LighthouseBsVector]):
+    def projection_pair_list(self) -> npt.NDArray:
+        result = np.empty((len(self), 2), dtype=float)
+        for i, vector in enumerate(self):
+            result[i] = vector.projection
+
+        return result

--- a/cflib/localization/lighthouse_bs_vector.py
+++ b/cflib/localization/lighthouse_bs_vector.py
@@ -19,6 +19,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
 import math
 
 import numpy as np
@@ -140,7 +142,7 @@ class LighthouseBsVector:
 # each sensor
 # LighthouseBsVectors = list[LighthouseBsVector]
 
-class LighthouseBsVectors(list[LighthouseBsVector]):
+class LighthouseBsVectors(list):
     def projection_pair_list(self) -> npt.NDArray:
         """
         Genereate a list of projection pairs for all vectors

--- a/cflib/localization/lighthouse_geometry_solver.py
+++ b/cflib/localization/lighthouse_geometry_solver.py
@@ -1,0 +1,460 @@
+from collections import namedtuple
+
+import numpy as np
+import numpy.typing as npt
+import scipy.optimize
+
+from cflib.localization.lighthouse_types import LhCfPoseSample
+from cflib.localization.lighthouse_types import Pose
+
+Ray = namedtuple('Ray', ['position', 'vector'])
+
+
+class LighthouseGeometrySolution:
+    """
+    Represents a solution from the geometry solver.
+
+    Some data in the object is also used during the solving process for context.
+    """
+
+    def __init__(self) -> None:
+        # Nr of parameters in a rotation vector
+        self.len_rot_vec = 3
+        # Nr of parameters
+        self.len_pose = 6
+
+        # Nr of base stations
+        self.n_bss: int = None
+        # Nr of parametrs per base station
+        self.n_params_per_bs = self.len_pose
+
+        # Nr of sampled Crazyflie poses
+        self.n_cfs: int = None
+        # Nr of sampled Crazyflie poses used in the parameter set
+        self.n_cfs_in_params: int = None
+        # Nr of parameters per Crazyflie pose
+        self.n_params_per_cf = self.len_pose
+
+        # Nr of sensors
+        self.n_sensors: int = None
+
+        # The maximum nr of iterations to execute when solving the system
+        self.max_nr_iter = 10
+
+        self.bs_id_to_index: dict[int, int] = {}
+        self.bs_index_to_id: dict[int, int] = {}
+
+        # The solution ######################
+
+        # The estimated poses of the base stations
+        self.bs_poses: dict[int, Pose] = {}
+
+        # The raw result from the scipy.optimize.least_squares() function
+        self.lsq_result = None
+
+    @property
+    def max_iter_reached(self):
+        """
+        True if the sover was terminated due to reaching the maximum nr of alowed iterations
+        """
+        result = False
+        if self.lsq_result is not None:
+            result = self.lsq_result == 0
+        return result
+
+
+class LighthouseGeometrySolver:
+    """
+    Finds the poses of base stations and Crazyflie samples given a list of matched samples.
+    The solver is iterative and uses least squares fitting to minimize the distance from
+    the lighthouse sensors to each "ray" measured in the samples.
+
+    The equation system that is solved is defined as:
+
+    Columns are the estimated poses (what we solve for). Each pose is composed of 6 numbers (often referred to as
+    parameters in the code): rotation vector (3) and position (3).
+
+    Rows are representing one angle from one base station. The number of rows for each sample is given by the
+    number of bs in the sample * n_sensors * 2.
+
+    An examples matrix:
+
+                        bs0_pose, bs1_pose, bs2_pose, bs3_pose, cf1_pose, cf2_pose, ...
+
+    cf0/bs2/sens0/ang0                        X
+    cf0/bs2/sens0/ang1                        X
+    cf0/bs2/sens1/ang0                        X
+    cf0/bs2/sens1/ang1                        X
+    ...
+    cf0/bs3/sens0/ang0                                  X
+    cf0/bs3/sens0/ang1                                  X
+    cf0/bs3/sens1/ang0                                  X
+    cf0/bs3/sens1/ang1                                  X
+    ...
+    cf1/bs1/sens0/ang0              X                             X
+    cf1/bs1/sens0/ang1              X                             X
+    cf1/bs1/sens1/ang0              X                             X
+    cf1/bs1/sens1/ang1              X                             X
+    ...
+    cf1/bs2/sens0/ang0                        X                   X
+    cf1/bs2/sens0/ang1                        X                   X
+    cf1/bs2/sens1/ang0                        X                   X
+    cf1/bs2/sens1/ang1                        X                   X
+    ...
+    cf2/bs1/sens0/ang0              X                                      X
+    cf2/bs1/sens0/ang1              X                                      X
+    cf2/bs1/sens1/ang0              X                                      X
+    cf2/bs1/sens1/ang1              X                                      X
+    ...
+    cf2/bs3/sens0/ang0                                  X                  X
+    cf2/bs3/sens0/ang1                                  X                  X
+    cf2/bs3/sens1/ang0                                  X                  X
+    cf2/bs3/sens1/ang1                                  X                  X
+    ...
+
+    """
+
+    @classmethod
+    def solve(cls, initial_guess_bs_poses: dict[int, Pose], matched_samples: list[LhCfPoseSample],
+              sensor_positions: npt.ArrayLike) -> LighthouseGeometrySolution:
+        """
+        Solve for the pose of base stations and CF samples.
+        The pose of the CF in sample 0 defines the global reference frame.
+
+        Iteration is terminated after a fixed number of iteration if acceptable solution
+        is found.
+
+        :param initial_guess_bs_poses: Initial guess for the base station poses
+        :param matched_samples: List of matched samples, must have been augmented with
+                                initial guesses of the CF poses
+        :param sensor_positions: Sensor positions (3D), in the CF reference frame
+        :return: an instance of LighthouseGeometrySolution
+        """
+        defs = LighthouseGeometrySolution()
+
+        defs.n_bss = len(initial_guess_bs_poses)
+        defs.n_cfs = len(matched_samples)
+        defs.n_cfs_in_params = len(matched_samples) - 1
+        defs.n_sensors = len(sensor_positions)
+        defs.bs_id_to_index, defs.bs_index_to_id = cls._crate_bs_map(initial_guess_bs_poses)
+
+        target_angles = cls._populate_target_angles(matched_samples, defs)
+        idx_agl_pr_to_bs, idx_agl_pr_to_cf, idx_agl_pr_to_sens_pos, jac_sparsity = cls._populate_indexes_and_jacobian(
+            matched_samples, defs)
+        params_bs, params_cfs = cls._populate_initial_guess(initial_guess_bs_poses, matched_samples, defs)
+
+        # Extra arguments passed on to calc_residual()
+        args = (defs, idx_agl_pr_to_bs, idx_agl_pr_to_cf, idx_agl_pr_to_sens_pos, target_angles, sensor_positions)
+
+        # Vector to optimize. Composed of base station parameters followed by cf parameters
+        x0 = np.hstack((params_bs.ravel(), params_cfs.ravel()))
+
+        result = scipy.optimize.least_squares(cls._calc_residual,
+                                              x0,
+                                              verbose=0,
+                                              jac_sparsity=jac_sparsity,
+                                              x_scale='jac',
+                                              ftol=1e-8,
+                                              method='trf',
+                                              max_nfev=defs.max_nr_iter,
+                                              args=args)
+
+        defs.lsq_result = result
+
+        bss, cf_poses = cls._params_to_struct(result.x, defs)
+
+        matched_samples[0].estimated_pose = Pose()
+        for i, sample in enumerate(matched_samples[1:]):
+            sample.estimated_pose = cls._params_to_pose(cf_poses[i], defs)
+
+        defs.bs_poses = {}
+        for index, pose in enumerate(bss):
+            bs_id = defs.bs_index_to_id[index]
+            defs.bs_poses[bs_id] = cls._params_to_pose(pose, defs)
+
+        return defs
+
+    @classmethod
+    def _populate_target_angles(cls, matched_samples: list[LhCfPoseSample], defs: LighthouseGeometrySolution
+                                ) -> npt.NDArray:
+        """
+        A np.array of all measured angles, the target angles
+        """
+        result = []
+        for sample in matched_samples:
+            for bs_id, angles in sorted(sample.angles_calibrated.items()):
+                result += angles.angle_list().tolist()
+
+        return np.array(result)
+
+    @classmethod
+    def _populate_indexes_and_jacobian(cls, matched_samples: list[LhCfPoseSample], defs: LighthouseGeometrySolution
+                                       ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
+        """
+        To speed up calculations all operations in the iteration phase are done on np.arrays of equal length (ish),
+        the numpy flavour of parallell work. Some data is reused in multiple equations (for instance sensor
+        positions) and to avoid copying of data we use np.arrays as indexes. This method creates the necessary
+        indexes.
+
+        Since the equation system we are solving is sparse, we can also do a second optimization and only calculate
+        the parts of the matrix that are non-zero. We have to provide a matrix containing 1 in the positions where
+        the jacobian is non-zero, this matrix is also generated here.
+        """
+        index_angle_pair_to_bs = []
+        index_angle_pair_to_cf = []
+        index_angle_pair_to_sensor_base = []
+
+        # Note: Indexes are for angle pairs, that is one set of indexes for two equations in the matrix.
+        # Each set of indexes will result in two angles, horizontal and vertical, which means there is one set of
+        # indexes per sensor.
+
+        for cf_i, sample in enumerate(matched_samples):
+            for bs_id in sorted(sample.angles_calibrated.keys()):
+                bs_index = defs.bs_id_to_index[bs_id]
+                for sensor_i in range(defs.n_sensors):
+                    index_angle_pair_to_cf.append(cf_i)
+                    index_angle_pair_to_bs.append(bs_index)
+                    index_angle_pair_to_sensor_base.append(sensor_i)
+
+        # Length of residual vector
+        len_residual_vec = len(index_angle_pair_to_cf) * 2
+
+        # Length of param vector
+        len_param_vec = defs.n_bss * defs.n_params_per_bs + defs.n_cfs_in_params * defs.n_params_per_cf
+
+        # The jac_sparsity matrix should have ones in all locations where data is used in the equations
+        jac_sparsity = scipy.sparse.lil_matrix((len_residual_vec, len_param_vec), dtype=int)
+        row_i = 0
+        n_tot_bs_params = defs.n_bss * defs.n_params_per_bs
+        for cf_i, sample in enumerate(matched_samples):
+            for bs_id in sorted(sample.angles_calibrated.keys()):
+                bs_index = defs.bs_id_to_index[bs_id]
+                for sensor_i in range(defs.n_sensors * 2):
+                    # Add bs parameters
+                    first = bs_index * defs.n_params_per_bs
+                    for i in range(first, first + defs.n_params_per_bs):
+                        jac_sparsity[row_i, i] = 1
+                    # Add cf parameters
+                    if cf_i > 0:
+                        first = n_tot_bs_params + (cf_i - 1) * defs.n_params_per_cf
+                        for i in range(first, first + defs.n_params_per_cf):
+                            jac_sparsity[row_i, i] = 1
+
+                    row_i += 1
+
+        return (np.array(index_angle_pair_to_bs),
+                np.array(index_angle_pair_to_cf),
+                np.array(index_angle_pair_to_sensor_base),
+                jac_sparsity)
+
+    @classmethod
+    def _populate_initial_guess(cls, initial_guess_bs_poses: list[Pose], matched_samples: list[LhCfPoseSample],
+                                defs: LighthouseGeometrySolution) -> tuple[npt.NDArray, npt.NDArray]:
+        """
+        Generate parameters for base stations and CFs, this is the initial guess we start to iterate from.
+        """
+        params_bs = np.zeros((len(initial_guess_bs_poses) * defs.n_params_per_bs))
+        for bs_id, pose in initial_guess_bs_poses.items():
+            index = defs.bs_id_to_index[bs_id] * defs.n_params_per_bs
+            params_bs[index:index + defs.n_params_per_bs] = cls._pose_to_params(pose)
+
+        # Skip the first CF pose, it is the definition of the origin and is not a parameter
+        params_cfs = []
+        for sample in matched_samples[1:]:
+            params_cfs.append(cls._pose_to_params(sample.inital_est_pose))
+
+        return params_bs, np.array(params_cfs)
+
+    @classmethod
+    def _params_to_struct(cls, params, defs: LighthouseGeometrySolution):
+        """
+        Convert the params list to two arrays, one for base stations and one for CFs
+        """
+        bs_param_count = defs.n_bss * defs.n_params_per_bs
+        params_bs_poses = params[:bs_param_count].reshape((defs.n_bss, defs.n_params_per_bs))
+
+        params_cf_poses = params[bs_param_count:].reshape((defs.n_cfs_in_params, defs.n_params_per_cf))
+
+        return params_bs_poses, params_cf_poses
+
+    @classmethod
+    def _calc_residual(cls, params, defs: LighthouseGeometrySolution, index_angle_pair_to_bs, index_angle_pair_to_cf,
+                       index_angle_pair_to_sensor_base, target_angles, sensor_positions):
+        """
+        Calculate the residual for a set of parameters. The residual is defined as the distance from a sensor to the
+        plane given by a measured base station angle.
+
+        :param params: list of parameters for base stations and CFs
+        :param defs: information about the context
+        :param index_angle_pair_to_bs: index array to index into the base station part of the parameter set
+        :param index_angle_pair_to_cf: index array to index into the CF part of the parameter set
+        :param index_angle_pair_to_sensor_base: index array to index into the sensor position array
+        :param target_angles: the measured angles
+        :param sensor_positions: Array with sensor positions
+        :return: Array with residuals
+        """
+        bss, cfs = cls._params_to_struct(params, defs)
+
+        # The first CF pose is defining the origin and is added here
+        cfs_full = np.concatenate((np.zeros((1, defs.n_params_per_cf), dtype=float), cfs))
+
+        angle_pairs = cls._poses_to_angle_pairs(bss, cfs_full, sensor_positions, index_angle_pair_to_bs,
+                                                index_angle_pair_to_cf, index_angle_pair_to_sensor_base, defs)
+        angles = np.ravel(angle_pairs)
+
+        diff = angles - target_angles
+
+        # Calculate the error at the CF positions
+        distances_to_cfs = np.repeat(np.linalg.norm(
+            bss[index_angle_pair_to_bs] - cfs_full[index_angle_pair_to_cf], axis=1), 2)
+        residual = np.tan(diff) * distances_to_cfs
+
+        return residual
+
+    @classmethod
+    def _poses_to_angle_pairs(cls, bss, cf_poses, sensor_base_pos, index_angle_pair_to_bs, index_angle_pair_to_cf,
+                              index_angle_pair_to_sensor_base, defs: LighthouseGeometrySolution):
+        pairs = cls._calc_angle_pairs(bss[index_angle_pair_to_bs], cf_poses[index_angle_pair_to_cf],
+                                      sensor_base_pos[index_angle_pair_to_sensor_base], defs)
+        return pairs
+
+    @classmethod
+    def _calc_angle_pairs(cls, bs_p_a, cf_p_a, sens_pos_p_a, defs: LighthouseGeometrySolution):
+        """
+        Calculate angle pairs based on base station poses, cf poses and sensor positions
+
+        :param bs_p_a: Poses base stations
+        :param cf_p_a: Poses CFs
+        :paran sens_pos_p_a: Sensor positions
+        :return: angle pairs
+
+        All lists are equally long, one entry per output angle pair
+        """
+        sensor_points = cls._rotate_translate(sens_pos_p_a, cf_p_a[:, :defs.len_rot_vec], cf_p_a[:, defs.len_rot_vec:])
+
+        # translate and inverse rotate (-rotation vector == inverse rotation)
+        points_bs_ref = cls._rotate_translate(sensor_points - bs_p_a[:, defs.len_rot_vec:defs.n_params_per_bs],
+                                              -bs_p_a[:, :defs.len_rot_vec],
+                                              np.zeros_like(bs_p_a[:, defs.len_rot_vec:defs.n_params_per_bs]))
+
+        angle_pair = np.arctan2(points_bs_ref[:, 1:3], points_bs_ref[:, 0, np.newaxis])
+        return angle_pair
+
+    @classmethod
+    def _rotate_translate(cls, points, rot_vecs, translations):
+        """Rotate points by given rotation vectors and translate
+
+        Rodrigues' rotation formula is used.
+        """
+        theta = np.linalg.norm(rot_vecs, axis=1)[:, np.newaxis]
+        with np.errstate(invalid='ignore'):
+            v = rot_vecs / theta
+            v = np.nan_to_num(v)
+        dot = np.sum(points * v, axis=1)[:, np.newaxis]
+        cos_theta = np.cos(theta)
+        sin_theta = np.sin(theta)
+
+        return cos_theta * points + sin_theta * np.cross(v, points) + dot * (1 - cos_theta) * v + translations
+
+    @classmethod
+    def _pose_to_params(cls, pose: Pose) -> npt.NDArray:
+        """
+        Convert from Pose to the array format used in the solver
+        """
+        return np.concatenate((pose.rot_vec, pose.translation))
+
+    @classmethod
+    def _params_to_pose(cls, params: npt.ArrayLike, defs: LighthouseGeometrySolution) -> Pose:
+        """
+        Convert from the array format used in the solver to Pose
+        """
+        r_vec = params[:defs.len_rot_vec]
+        t = params[defs.len_rot_vec:defs.len_pose]
+        return Pose.from_rot_vec(R_vec=r_vec, t_vec=t)
+
+    @classmethod
+    def _crate_bs_map(cls, initial_guess_bs_poses: dict[int, Pose]) -> tuple[dict[int, int], dict[int, int]]:
+        """
+        We might have gaps in the list of base station ids that is used in the system, use an index instead
+        when refering to a base station. This method creates dictionaries to go from index to base station id,
+        or the other way around.
+
+        Base station ids are indexed in an increasing order which means that sorting keys will result
+        in sorted indexes as well.
+        """
+        bs_id_to_index = {}
+        bs_index_to_id = {}
+
+        for index, id in enumerate(sorted(initial_guess_bs_poses.keys())):
+            bs_id_to_index[id] = index
+            bs_index_to_id[index] = id
+
+        return bs_id_to_index, bs_index_to_id
+
+    # TODO
+
+    # @classmethod
+    # def estimate_error(cls, bs_poses, matched_samples, sensor_base_pos):
+    #     # Estimate the error (in meters) for all CF positions by calculating
+    #     # the distance from the ray (defined by measured angles/bs pose) to
+    #     # the estimated sensor position
+    #     for sample in matched_samples:
+    #         cf_pose = sample['pose']
+    #         errors = {}
+    #         for bs_id, angles in sample['data'].items():
+    #             # Only look at sensor 0
+    #             horiz = angles[0]
+    #             vert = angles[1]
+
+    #             bs_pose = bs_poses[bs_id]
+    #             ray = cls._calc_ray(bs_pose, horiz, vert)
+
+    #             sensor_pos = np.dot(cf_pose[0], sensor_base_pos[0]) + cf_pose[1]
+
+    #             error_dist = cls._distance_point_to_ray(sensor_pos, ray)
+    #             errors[bs_id] = error_dist
+    #         sample['error'] = errors
+
+    #     error_info = cls._analyze_errors(matched_samples)
+    #     return error_info
+
+    # @classmethod
+    # def _analyze_errors(cls, matched_samples):
+    #     error_per_bs = {}
+    #     errors = []
+    #     for sample in matched_samples:
+    #         for bs_id, error in sample['error'].items():
+    #             if bs_id not in error_per_bs:
+    #                 error_per_bs[bs_id] = []
+    #             error_per_bs[bs_id].append(error)
+    #             errors.append(error)
+
+    #     error_info = {}
+    #     error_info['mean_error'] = np.mean(errors)
+    #     error_info['max_error'] = np.max(errors)
+    #     error_info['std_error'] = np.std(errors)
+
+    #     error_info['bs'] = {}
+    #     for bs_id, errors in error_per_bs.items():
+    #         error_info['bs'][bs_id] = {}
+    #         error_info['bs'][bs_id]['mean_error'] = np.mean(errors)
+    #         error_info['bs'][bs_id]['max_error'] = np.max(errors)
+    #         error_info['bs'][bs_id]['std_error'] = np.std(errors)
+
+    #     return error_info
+
+    # @classmethod
+    # def _calc_ray(cls, geometry, horiz, vert):
+    #     n1 = np.array([np.sin(horiz), -np.cos(horiz), 0.0])
+    #     n2 = np.array([-np.sin(vert), 0.0, np.cos(vert)])
+
+    #     n21 = np.cross(n2, n1)
+    #     normal = n21 / np.linalg.norm(n21)
+
+    #     R = geometry[0]
+    #     vec = np.dot(R, normal)
+    #     return Ray(geometry[1], vec)
+
+    # @classmethod
+    # def _distance_point_to_ray(cls, point, ray):
+    #     return np.linalg.norm(np.cross(ray.vector, ray.position - point)) / np.linalg.norm(ray.vector)

--- a/cflib/localization/lighthouse_geometry_solver.py
+++ b/cflib/localization/lighthouse_geometry_solver.py
@@ -1,3 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2022 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
 import numpy as np
 import numpy.typing as npt
 import scipy.optimize
@@ -120,10 +143,8 @@ class LighthouseGeometrySolver:
         Iteration is terminated after a fixed number of iteration if acceptable solution
         is found.
 
-        :param initial_guess_bs_poses: Initial guess for the base station and CF sample poses
-        :param matched_samples: List of matched samples, must have been augmented with initial guesses of the CF
-                                poses. The samples will be updated with their estimated pose and error during the
-                                process.
+        :param initial_guess: Initial guess for the base stations and CF sample poses
+        :param matched_samples: List of matched samples.
         :param sensor_positions: Sensor positions (3D), in the CF reference frame
         :return: an instance of LighthouseGeometrySolution
         """

--- a/cflib/localization/lighthouse_geometry_solver.py
+++ b/cflib/localization/lighthouse_geometry_solver.py
@@ -78,6 +78,10 @@ class LighthouseGeometrySolution:
         # Information about errors in the solution
         self.error_info = {}
 
+        # Indicates if the solution coverged (True).
+        # If it did not converge, the solution is probably not good enough to use
+        self.success = False
+
 
 class LighthouseGeometrySolver:
     """
@@ -408,8 +412,7 @@ class LighthouseGeometrySolver:
             bs_id = solution.bs_index_to_id[index]
             solution.bs_poses[bs_id] = cls._params_to_pose(pose, solution)
 
-        if not lsq_result.success:
-            raise Exception('Solution did not converge')
+        solution.success = lsq_result.success
 
         # Extract the error for each CF pose
         residuals = lsq_result.fun

--- a/cflib/localization/lighthouse_geometry_solver.py
+++ b/cflib/localization/lighthouse_geometry_solver.py
@@ -401,8 +401,9 @@ class LighthouseGeometrySolver:
         bss, cf_poses = cls._params_to_struct(lsq_result.x, solution)
 
         # Extract CF pose estimates
+        # First pose (origin) is not in the parameter list
         solution.cf_poses.append(Pose())
-        for i, sample in enumerate(matched_samples[1:]):
+        for i in range(len(matched_samples) - 1):
             solution.cf_poses.append(cls._params_to_pose(cf_poses[i], solution))
 
         # Extract base station pose estimates

--- a/cflib/localization/lighthouse_geometry_solver.py
+++ b/cflib/localization/lighthouse_geometry_solver.py
@@ -285,7 +285,7 @@ class LighthouseGeometrySolver:
 
         # Calculate the error at the CF positions
         distances_to_cfs = np.repeat(np.linalg.norm(
-            bss[index_angle_pair_to_bs] - cfs_full[index_angle_pair_to_cf], axis=1), 2)
+            bss[index_angle_pair_to_bs][:,3:] - cfs_full[index_angle_pair_to_cf][:,3:], axis=1), 2)
         residual = np.tan(diff) * distances_to_cfs
 
         return residual

--- a/cflib/localization/lighthouse_geometry_solver.py
+++ b/cflib/localization/lighthouse_geometry_solver.py
@@ -59,7 +59,7 @@ class LighthouseGeometrySolution:
         self.n_sensors: int = None
 
         # The maximum nr of iterations to execute when solving the system
-        self.max_nr_iter = 10
+        self.max_nr_iter = 100
 
         self.bs_id_to_index: dict[int, int] = {}
         self.bs_index_to_id: dict[int, int] = {}

--- a/cflib/localization/lighthouse_geometry_solver.py
+++ b/cflib/localization/lighthouse_geometry_solver.py
@@ -78,9 +78,6 @@ class LighthouseGeometrySolution:
         # Information about errors in the solution
         self.error_info = {}
 
-        # True if the sover was terminated due to reaching the maximum nr of alowed iterations
-        self.max_iter_reached: bool = False
-
 
 class LighthouseGeometrySolver:
     """
@@ -411,7 +408,8 @@ class LighthouseGeometrySolver:
             bs_id = solution.bs_index_to_id[index]
             solution.bs_poses[bs_id] = cls._params_to_pose(pose, solution)
 
-        solution.max_iter_reached = lsq_result == 0
+        if not lsq_result.success:
+            raise Exception('Solution did not converge')
 
         # Extract the error for each CF pose
         residuals = lsq_result.fun

--- a/cflib/localization/lighthouse_initial_estimator.py
+++ b/cflib/localization/lighthouse_initial_estimator.py
@@ -19,6 +19,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
 import numpy as np
 import numpy.typing as npt
 

--- a/cflib/localization/lighthouse_initial_estimator.py
+++ b/cflib/localization/lighthouse_initial_estimator.py
@@ -54,7 +54,6 @@ class LighthouseInitialEstimator:
 
         # Use the first CF pose as the global reference frame
         bs_poses: dict[int, Pose] = bs_poses_ref_cfs[0]
-        # TODO Do not use first sample as reference, pass it in as a parameter
 
         cls._calc_remaining_bs_poses(bs_poses_ref_cfs, bs_poses)
         cf_poses = cls._calc_cf_poses(bs_poses_ref_cfs, bs_poses)

--- a/cflib/localization/lighthouse_initial_estimator.py
+++ b/cflib/localization/lighthouse_initial_estimator.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2022 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import numpy as np
+import numpy.typing as npt
+
+from .ippe_cf import IppeCf
+from cflib.localization.lighthouse_types import LhCfPoseSample
+from cflib.localization.lighthouse_types import Pose
+
+
+class LighthouseInitialEstimator:
+    """
+    Make initial estimates of base station and CF poses useing IPPE (analytical solution).
+    The estimates are not good enough to use for flight but is a starting point for further
+    Calculations.
+    """
+
+    @classmethod
+    def estimate(cls, matched_samples: list[LhCfPoseSample], sensor_positions: npt.ArrayLike) -> dict[int, Pose]:
+        """
+        Make a rough estimate of the poses of all base stations found in the samples.
+
+        The pose of the Crazyflie in the first sample is used as a reference and will define the
+        global reference frame.
+
+        :param matched_samples: A list of samples with lihghthouse angles. Note: matched_samples is augmented with
+                                more information during the process, including the estimated poses
+        :param sensor_positions: An array with the sensor positions on the lighthouse deck (3D, CF ref frame)
+        """
+
+        cls._angles_to_poses(matched_samples, sensor_positions)
+
+        # TODO Do not use first sample as reference, pass it in as a parameter
+
+        bs_poses: dict[int, Pose] = {}
+        cls._get_reference_bs_poses(matched_samples[0], bs_poses)
+        cls._calc_remaining_bs_poses(matched_samples, bs_poses)
+        cls._calc_cf_poses(matched_samples, bs_poses)
+
+        return bs_poses
+
+    @classmethod
+    def _angles_to_poses(cls, matched_samples: list[LhCfPoseSample], sensor_positions: npt.ArrayLike) -> None:
+        for sample in matched_samples:
+            poses: dict[int, Pose] = {}
+            for bs, angles in sample.angles_calibrated.items():
+                Q = angles.projection_pair_list()
+                estimate = IppeCf.solve(sensor_positions, Q)
+
+                # Pick the first solution from IPPE and convert to cf ref frame
+                R_mat = estimate[0][0].transpose()
+                t_vec = np.dot(R_mat, -estimate[0][1])
+
+                poses[bs] = Pose(R_mat, t_vec)
+            sample.initial_est_bs_poses = poses
+
+    @classmethod
+    def _get_reference_bs_poses(cls, sample: LhCfPoseSample, bs_poses: dict[int, Pose]) -> None:
+        """
+        The Pose of the CF in this sample is defining the global ref frame.
+        Store the poses for the bases stations that are in the sample.
+        """
+        est_ref_cf = sample.initial_est_bs_poses
+        for bs, pose in est_ref_cf.items():
+            bs_poses[bs] = pose
+
+    @classmethod
+    def _calc_remaining_bs_poses(cls, matched_sampels: list[LhCfPoseSample], bs_poses: dict[int, Pose]) -> None:
+        # Find all base stations in the list
+        all_bs = set()
+        for sample in matched_sampels:
+            all_bs.update(sample.initial_est_bs_poses.keys())
+
+        # Remove the reference base stations that we already have the poses for
+        to_find = all_bs - bs_poses.keys()
+
+        # run through the list of samples until we manage to find them all
+        remaining = len(to_find)
+        while remaining > 0:
+            for sample in matched_sampels:
+                bs_poses_in_sample = sample.initial_est_bs_poses
+                unknown = to_find.intersection(bs_poses_in_sample.keys())
+                known = set(bs_poses.keys()).intersection(bs_poses_in_sample.keys())
+
+                # We need (at least) one known bs pose to use when transforming the other poses to the global ref frame
+                if len(known) > 0:
+                    known_bs = list(known)[0]
+
+                    # The known BS pose in the global reference frame
+                    known_global = bs_poses[known_bs]
+                    # The known BS pose in the CF reference frame (of this sample)
+                    known_cf = bs_poses_in_sample[known_bs]
+
+                    for bs in unknown:
+                        # The unknown BS pose in the CF reference frame (of this sample)
+                        unknown_cf = bs_poses_in_sample[bs]
+                        # Finally we can calculate the BS pose in the global reference frame
+                        bs_poses[bs] = cls._map_pose_to_ref_frame(known_global, known_cf, unknown_cf)
+
+                to_find = all_bs - bs_poses.keys()
+                if len(to_find) == 0:
+                    break
+
+            if len(to_find) == remaining:
+                raise Exception('Can not link positions between all base stations')
+
+            remaining = len(to_find)
+
+    @classmethod
+    def _calc_cf_poses(cls, matched_samples: list[LhCfPoseSample], bs_poses: list[Pose]) -> None:
+        for sample in matched_samples:
+            # Use the first base station pose as a reference
+            est_ref_cf = sample.initial_est_bs_poses
+            ref_bs = list(est_ref_cf.keys())[0]
+
+            pose_global = bs_poses[ref_bs]
+            pose_cf = est_ref_cf[ref_bs]
+            est_ref_global = cls._map_cf_pos_to_cf_pos(pose_global, pose_cf)
+            sample.inital_est_pose = est_ref_global
+
+    @classmethod
+    def _map_pose_to_ref_frame(cls, pose1_ref1: Pose, pose1_ref2: Pose, pose2_ref2: Pose) -> Pose:
+        """
+        Express pose2 in reference system 1, given pose1 in both reference system 1 and 2
+        """
+        R_o2_in_1, t_o2_in_1 = cls._map_cf_pos_to_cf_pos(pose1_ref1, pose1_ref2).matrix_vec
+
+        t = np.dot(R_o2_in_1, pose2_ref2.translation) + t_o2_in_1
+        R = np.dot(R_o2_in_1, pose2_ref2.rot_matrix)
+
+        return Pose(R, t)
+
+    @classmethod
+    def _map_cf_pos_to_cf_pos(cls, pose1_ref1: Pose, pose1_ref2: Pose) -> Pose:
+        """
+        Find the rotation/translation from ref1 to ref2 given a pose,
+        that is the returned Pose will tell us where the origin in ref2 is,
+        expressed in ref1
+        """
+
+        R_inv_ref2 = np.matrix.transpose(pose1_ref2.rot_matrix)
+        R = np.dot(pose1_ref1.rot_matrix, R_inv_ref2)
+        t = pose1_ref1.translation - np.dot(R, pose1_ref2.translation)
+
+        return Pose(R, t)

--- a/cflib/localization/lighthouse_sample_matcher.py
+++ b/cflib/localization/lighthouse_sample_matcher.py
@@ -55,5 +55,5 @@ class LighthouseSampleMatcher:
 
     @classmethod
     def _append_result(cls, current: LhCfPoseSample, result: list[LhCfPoseSample], min_nr_of_bs_in_match: int):
-        if len(current.angles_calibrated) > min_nr_of_bs_in_match:
+        if current is not None and len(current.angles_calibrated) >= min_nr_of_bs_in_match:
             result.append(current)

--- a/cflib/localization/lighthouse_sample_matcher.py
+++ b/cflib/localization/lighthouse_sample_matcher.py
@@ -19,6 +19,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
 from cflib.localization.lighthouse_types import LhCfPoseSample
 from cflib.localization.lighthouse_types import LhMeasurement
 

--- a/cflib/localization/lighthouse_sample_matcher.py
+++ b/cflib/localization/lighthouse_sample_matcher.py
@@ -19,8 +19,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-
-from cflib.localization.lighthouse_types import LhCfPoseSample, LhMeasurement
+from cflib.localization.lighthouse_types import LhCfPoseSample
+from cflib.localization.lighthouse_types import LhMeasurement
 
 
 class LighthouseSampleMatcher:
@@ -32,7 +32,9 @@ class LighthouseSampleMatcher:
     """
 
     @classmethod
-    def match(cls, samples: list[LhMeasurement], max_time_diff: float =0.010, min_nr_of_bs_in_match: int =0) -> list[LhCfPoseSample]:
+    def match(cls, samples: list[LhMeasurement], max_time_diff: float = 0.010,
+              min_nr_of_bs_in_match: int = 0) -> list[LhCfPoseSample]:
+
         result = []
         current: LhCfPoseSample = None
 

--- a/cflib/localization/lighthouse_sample_matcher.py
+++ b/cflib/localization/lighthouse_sample_matcher.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2022 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from cflib.localization.lighthouse_types import LhCfPoseSample, LhMeasurement
+
+
+class LighthouseSampleMatcher:
+    """Utility class to match samples of measurements from multiple lighthouse base stations.
+
+    Assuming that the Crazyflie was moving when the measurements were recorded,
+    samples that were meassured aproximately at the same position are aggregated into
+    a list of LhCfPoseSample. Matching is done using the timestamp and a maximum time span.
+    """
+
+    @classmethod
+    def match(cls, samples: list[LhMeasurement], max_time_diff: float =0.010, min_nr_of_bs_in_match: int =0) -> list[LhCfPoseSample]:
+        result = []
+        current: LhCfPoseSample = None
+
+        for sample in samples:
+            ts = sample.timestamp
+
+            if current is None:
+                current = LhCfPoseSample(timestamp=ts)
+
+            if ts > (current.timestamp + max_time_diff):
+                cls._append_result(current, result, min_nr_of_bs_in_match)
+                current = LhCfPoseSample(timestamp=ts)
+
+            current.angles_calibrated[sample.base_station_id] = sample.angles
+
+        cls._append_result(current, result, min_nr_of_bs_in_match)
+        return result
+
+    @classmethod
+    def _append_result(cls, current: LhCfPoseSample, result: list[LhCfPoseSample], min_nr_of_bs_in_match: int):
+        if len(current.angles_calibrated) > min_nr_of_bs_in_match:
+            result.append(current)

--- a/cflib/localization/lighthouse_sweep_angle_reader.py
+++ b/cflib/localization/lighthouse_sweep_angle_reader.py
@@ -6,7 +6,7 @@
 # | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
 #    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
 #
-# Copyright (C) 2021 Bitcraze AB
+# Copyright (C) 2021-2022 Bitcraze AB
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/cflib/localization/lighthouse_sweep_angle_reader.py
+++ b/cflib/localization/lighthouse_sweep_angle_reader.py
@@ -20,6 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 from cflib.localization import LighthouseBsVector
+from cflib.localization.lighthouse_bs_vector import LighthouseBsVectors
 
 
 class LighthouseSweepAngleReader():
@@ -66,7 +67,7 @@ class LighthouseSweepAngleReader():
             for i in range(self.NR_OF_SENSORS):
                 result.append(LighthouseBsVector(horiz_angles[i], vert_angles[i]))
 
-            self._cb(base_station_id, result)
+            self._cb(base_station_id, LighthouseBsVectors(result))
 
 
 class LighthouseSweepAngleAverageReader():
@@ -142,7 +143,7 @@ class LighthouseSweepAngleAverageReader():
         for i in range(self._reader.NR_OF_SENSORS):
             result.append(self._average_sample_list(sample_lists[i]))
 
-        return result
+        return LighthouseBsVectors(result)
 
     def _average_sample_list(self, sample_list):
         sum_horiz = 0.0

--- a/cflib/localization/lighthouse_system_aligner.py
+++ b/cflib/localization/lighthouse_system_aligner.py
@@ -54,17 +54,18 @@ class LighthouseSystemAligner:
         return result
 
     @classmethod
-    def find_transformation(cls, origin: npt.ArrayLike, x_axis: list[npt.ArrayLike], xy_plane: list[npt.ArrayLike]) -> Pose:
+    def find_transformation(cls, origin: npt.ArrayLike, x_axis: list[npt.ArrayLike],
+                            xy_plane: list[npt.ArrayLike]) -> Pose:
         """
-        Finds the transformation from the current reference frame to a desired reference frame based on measured positions
-        of the desired reference frame.
+        Finds the transformation from the current reference frame to a desired reference frame based on measured
+        positions of the desired reference frame.
 
         :param origin: The position of the desired origin in the current reference frame
         :param x_axis: One or more positions on the desired positive X-axis (X>0, Y=Z=0) in the current
                        reference frame
         :param x_axis: One or more positions in the desired XY-plane (Z=0) in the current reference frame
-        :return: The transformation from the current reference frame to the desired reference frame. Note: the solution may
-                 be flipped.
+        :return: The transformation from the current reference frame to the desired reference frame. Note: the
+                 solution may be flipped.
         """
         args = (origin, x_axis, xy_plane)
 
@@ -104,7 +105,8 @@ class LighthouseSystemAligner:
         return Pose.from_rot_vec(R_vec=params[:3], t_vec=params[3:])
 
     @classmethod
-    def _de_flip_transformation(cls, raw_transformation: Pose, x_axis: list[npt.ArrayLike], bs_poses: dict[int, Pose]) -> Pose:
+    def _de_flip_transformation(cls, raw_transformation: Pose, x_axis: list[npt.ArrayLike],
+                                bs_poses: dict[int, Pose]) -> Pose:
         """
         Investigats a transformation and flips it if needed. This method assumes that
         1. all base stations are at Z>0

--- a/cflib/localization/lighthouse_system_aligner.py
+++ b/cflib/localization/lighthouse_system_aligner.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2021-2022 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import numpy as np
+import numpy.typing as npt
+import scipy.optimize
+from cflib.localization.lighthouse_types import Pose
+
+
+class LighthouseSystemAligner:
+    @classmethod
+    def align(cls, origin: npt.ArrayLike, x_axis: list[npt.ArrayLike], xy_plane: list[npt.ArrayLike],
+              bs_poses: dict[int, Pose]) -> dict[int, Pose]:
+        """
+        Align a coordinate system with the physical world. Finds the transform from the
+        current reference frame to one that is aligned with measured positions, and transforms base station
+        poses to the new coordinate system.
+
+        :param origin: The position of the desired origin in the current reference frame
+        :param x_axis: One or more positions on the desired positive X-axis (X>0, Y=Z=0) in the current
+                       reference frame
+        :param x_axis: One or more positions in the desired XY-plane (Z=0) in the current reference frame
+        :param bs_poses: a dictionary with the base station poses in the current reference frame
+        :return: a dictionary with the base station poses in the desired reference frame
+        """
+        raw_transformation = cls.find_transformation(origin, x_axis, xy_plane)
+        transformation = cls._de_flip_transformation(raw_transformation, x_axis, bs_poses)
+
+        result: dict[int, Pose] = {}
+        for bs_id, pose in bs_poses.items():
+            result[bs_id] = transformation.rotate_translate_pose(pose)
+
+        return result
+
+    @classmethod
+    def find_transformation(cls, origin: npt.ArrayLike, x_axis: list[npt.ArrayLike], xy_plane: list[npt.ArrayLike]) -> Pose:
+        """
+        Finds the transformation from the current reference frame to a desired reference frame based on measured positions
+        of the desired reference frame.
+
+        :param origin: The position of the desired origin in the current reference frame
+        :param x_axis: One or more positions on the desired positive X-axis (X>0, Y=Z=0) in the current
+                       reference frame
+        :param x_axis: One or more positions in the desired XY-plane (Z=0) in the current reference frame
+        :return: The transformation from the current reference frame to the desired reference frame. Note: the solution may
+                 be flipped.
+        """
+        args=(origin, x_axis, xy_plane)
+
+        x0 = np.zeros((6))
+
+        result = scipy.optimize.least_squares(cls._calc_residual,
+                                              x0, verbose=0,
+                                              jac_sparsity=None,
+                                              x_scale='jac',
+                                              ftol=1e-8,
+                                              method='trf',
+                                              max_nfev=10,
+                                              args=args)
+        return cls._Pose_from_params(result.x)
+
+    @classmethod
+    def _calc_residual(cls, params, origin: npt.ArrayLike, x_axis: list[npt.ArrayLike], xy_plane: list[npt.ArrayLike]):
+        transform = cls._Pose_from_params(params)
+
+        origin_diff = transform.rotate_translate(origin)
+        x_axis_diff = map(lambda x: transform.rotate_translate(x), x_axis)
+        xy_plane_diff = map(lambda x: transform.rotate_translate(x), xy_plane)
+
+        residual_origin = origin_diff
+
+        # Points on X-axis: ignore X
+        x_axis_residual = list(map(lambda x: x[1:3], x_axis_diff))
+
+        # Points in the XY-plane: ignore X and Y
+        xy_plane_residual = list(map(lambda x: x[2], xy_plane_diff))
+
+        residual = np.concatenate((np.ravel(residual_origin), np.ravel(x_axis_residual), np.ravel(xy_plane_residual)))
+        return residual
+
+    @classmethod
+    def _Pose_from_params(cls, params: npt.ArrayLike) -> Pose:
+        return Pose.from_rot_vec(R_vec=params[:3], t_vec=params[3:])
+
+    @classmethod
+    def _de_flip_transformation(cls, raw_transformation: Pose, x_axis: list[npt.ArrayLike], bs_poses: dict[int, Pose]) -> Pose:
+        """
+        Investigats a transformation and flips it if needed. This method assumes that
+        1. all base stations are at Z>0
+        2. x_axis samples are taken at x>0
+        """
+        transformation = raw_transformation
+
+        # X-axis poses should be on the positivie X-axis, check the first one
+        if raw_transformation.rotate_translate(x_axis[0])[0] < 0.0:
+            flip_around_z_axis = Pose.from_rot_vec(R_vec=(0.0, 0.0, np.pi))
+            transformation = flip_around_z_axis.rotate_translate_pose(transformation)
+
+        # Base station poses should be above the floor, check the first one
+        bs_pose = list(bs_poses.values())[0]
+        if raw_transformation.rotate_translate(bs_pose.translation)[2] < 0.0:
+            flip_around_x_axis = Pose.from_rot_vec(R_vec=(np.pi, 0.0, 0.0))
+            transformation = flip_around_x_axis.rotate_translate_pose(transformation)
+
+        return transformation

--- a/cflib/localization/lighthouse_system_aligner.py
+++ b/cflib/localization/lighthouse_system_aligner.py
@@ -19,9 +19,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
 import numpy as np
 import numpy.typing as npt
 import scipy.optimize
+
 from cflib.localization.lighthouse_types import Pose
 
 
@@ -63,7 +66,7 @@ class LighthouseSystemAligner:
         :return: The transformation from the current reference frame to the desired reference frame. Note: the solution may
                  be flipped.
         """
-        args=(origin, x_axis, xy_plane)
+        args = (origin, x_axis, xy_plane)
 
         x0 = np.zeros((6))
 

--- a/cflib/localization/lighthouse_types.py
+++ b/cflib/localization/lighthouse_types.py
@@ -124,6 +124,9 @@ class LhCfPoseSample:
         # The initial estimate of the CF pose for this sample, in the global ref frame
         self.inital_est_pose: Pose = None
 
+        # The refined estimate of the CF pose for this sample, in the global ref frame
+        self.estimated_pose: Pose = None
+
 
 class LhDeck4SensorPositions:
     """ Positions of the sensors on the Lighthouse 4 deck """

--- a/cflib/localization/lighthouse_types.py
+++ b/cflib/localization/lighthouse_types.py
@@ -19,6 +19,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
+
 from typing import NamedTuple
 
 import numpy as np

--- a/cflib/localization/lighthouse_types.py
+++ b/cflib/localization/lighthouse_types.py
@@ -92,6 +92,26 @@ class Pose:
         """
         return np.dot(np.transpose(self.rot_matrix), point - self.translation)
 
+    def rotate_translate_pose(self, pose: 'Pose') -> 'Pose':
+        """
+        Rotate and translate a pose
+        """
+        t = np.dot(self.rot_matrix, pose.translation) + self.translation
+        R = np.dot(self.rot_matrix, pose.rot_matrix)
+
+        return Pose(R_matrix=R, t_vec=t)
+
+    def inv_rotate_translate_pose(self, pose: 'Pose') -> 'Pose':
+        """
+        Inverse rotate and translate a point, that is transform from global
+        to local reference frame
+        """
+        inv_rot_matrix = np.transpose(self.rot_matrix)
+        t = np.dot(inv_rot_matrix, pose.translation - self.translation)
+        R = np.dot(inv_rot_matrix, pose.rot_matrix)
+
+        return Pose(R_matrix=R, t_vec=t)
+
 
 class LhMeasurement(NamedTuple):
     """Represents a measurement from one base station."""

--- a/cflib/localization/lighthouse_types.py
+++ b/cflib/localization/lighthouse_types.py
@@ -127,6 +127,9 @@ class LhCfPoseSample:
         # The refined estimate of the CF pose for this sample, in the global ref frame
         self.estimated_pose: Pose = None
 
+        # The aprroximate errors in final solution
+        self.estimated_errors: dict[int, float] = {}
+
 
 class LhDeck4SensorPositions:
     """ Positions of the sensors on the Lighthouse 4 deck """

--- a/cflib/localization/lighthouse_types.py
+++ b/cflib/localization/lighthouse_types.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2022 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from typing import NamedTuple
+import numpy as np
+import numpy.typing as npt
+
+from cflib.localization.lighthouse_bs_vector import LighthouseBsVector
+
+class Pose:
+    """ Holds the full pose (position and orientation) of an object.
+    Contains functionality to convert between various formats."""
+
+    def __init__(self, R_matrix: npt.ArrayLike, t_vec: npt.ArrayLike) -> None:
+        # Rotation as a matix
+        self.R_matrix = np.array(R_matrix)
+
+        # Rotation as a Rodrigues vector
+        self.R_vec = None
+
+        self.t_vec = np.array(t_vec)
+
+    def matrix_vec():
+        pass
+
+    def rotvec_vec():
+        pass
+
+    def rotvec_vec_list():
+        pass
+
+
+class LhMeasurement(NamedTuple):
+    """Represents a measurement from one base station."""
+    timestamp: float
+    base_station_id: int
+    angles: LighthouseBsVector
+
+
+class LhCfPoseSample:
+    """ Represents a sample of a Crazyflie pose in space, it contains
+    various data related to the pose such as:
+    - lighthouse angles from one or more base stations
+    - initial estimate of the pose
+    - refined estimate of the pose
+    - estimated errors
+    """
+
+    def __init__(self, timestamp: float =0.0) -> None:
+        self.timestamp: float = timestamp
+        self.angles_calibrated = {}

--- a/cflib/localization/lighthouse_types.py
+++ b/cflib/localization/lighthouse_types.py
@@ -100,6 +100,12 @@ class LhMeasurement(NamedTuple):
     angles: LighthouseBsVectors
 
 
+class LhBsCfPoses(NamedTuple):
+    """Represents all poses of base stations and CF samples"""
+    bs_poses: dict[int, Pose]
+    cf_poses: list[Pose]
+
+
 class LhCfPoseSample:
     """ Represents a sample of a Crazyflie pose in space, it contains
     various data related to the pose such as:
@@ -117,18 +123,6 @@ class LhCfPoseSample:
         self.angles_calibrated: dict[int, LighthouseBsVectors] = angles_calibrated
         if self.angles_calibrated is None:
             self.angles_calibrated = {}
-
-        # Initial estimates of bs poses for this sample, in the CF reference frame
-        self.initial_est_bs_poses: dict[int, Pose] = {}
-
-        # The initial estimate of the CF pose for this sample, in the global ref frame
-        self.inital_est_pose: Pose = None
-
-        # The refined estimate of the CF pose for this sample, in the global ref frame
-        self.estimated_pose: Pose = None
-
-        # The aprroximate errors in final solution
-        self.estimated_errors: dict[int, float] = {}
 
 
 class LhDeck4SensorPositions:

--- a/cflib/localization/lighthouse_types.py
+++ b/cflib/localization/lighthouse_types.py
@@ -19,41 +19,85 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-
 from typing import NamedTuple
+
 import numpy as np
 import numpy.typing as npt
+from scipy.spatial.transform import Rotation
 
-from cflib.localization.lighthouse_bs_vector import LighthouseBsVector
+from cflib.localization.lighthouse_bs_vector import LighthouseBsVectors
+
 
 class Pose:
     """ Holds the full pose (position and orientation) of an object.
     Contains functionality to convert between various formats."""
 
-    def __init__(self, R_matrix: npt.ArrayLike, t_vec: npt.ArrayLike) -> None:
+    _NO_ROTATION_MTX = np.identity(3)
+    _NO_ROTATION_VCT = np.array((0.0, 0.0, 0.0))
+    _ORIGIN = np.array((0.0, 0.0, 0.0))
+
+    def __init__(self, R_matrix: npt.ArrayLike = _NO_ROTATION_MTX, t_vec: npt.ArrayLike = _ORIGIN) -> None:
         # Rotation as a matix
-        self.R_matrix = np.array(R_matrix)
+        self._R_matrix = np.array(R_matrix)
 
-        # Rotation as a Rodrigues vector
-        self.R_vec = None
+        # Translation vector
+        self._t_vec = np.array(t_vec)
 
-        self.t_vec = np.array(t_vec)
+    @classmethod
+    def from_rot_vec(cls, R_vec: npt.ArrayLike = _NO_ROTATION_VCT, t_vec: npt.ArrayLike = _ORIGIN) -> 'Pose':
+        """
+        Create a Pose from a rotation vector and translation vector
+        """
+        return Pose(Rotation.from_rotvec(R_vec).as_matrix(), t_vec)
 
-    def matrix_vec():
-        pass
+    @property
+    def rot_matrix(self) -> npt.NDArray:
+        """
+        Get the rotation matrix of the pose
+        """
+        return self._R_matrix
 
-    def rotvec_vec():
-        pass
+    @property
+    def rot_vec(self) -> npt.NDArray:
+        """
+        Get the rotation vector of the pose
+        """
+        return Rotation.from_matrix(self._R_matrix).as_rotvec()
 
-    def rotvec_vec_list():
-        pass
+    @property
+    def translation(self) -> npt.NDArray:
+        """
+        Get the translation vector of the pose
+        """
+        return self._t_vec
+
+    @property
+    def matrix_vec(self) -> tuple[npt.NDArray, npt.NDArray]:
+        """
+        Get the pose as a rotation matrix and translation vector
+        """
+        return self._R_matrix, self._t_vec
+
+    def rotate_translate(self, point: npt.ArrayLike) -> npt.NDArray:
+        """
+        Rotate and translate a point, that is transform from local
+        to global reference frame
+        """
+        return np.dot(self.rot_matrix, point) + self.translation
+
+    def inv_rotate_translate(self, point: npt.ArrayLike) -> npt.NDArray:
+        """
+        Inverse rotate and translate a point, that is transform from global
+        to local reference frame
+        """
+        return np.dot(np.transpose(self.rot_matrix), point - self.translation)
 
 
 class LhMeasurement(NamedTuple):
     """Represents a measurement from one base station."""
     timestamp: float
     base_station_id: int
-    angles: LighthouseBsVector
+    angles: LighthouseBsVectors
 
 
 class LhCfPoseSample:
@@ -65,6 +109,31 @@ class LhCfPoseSample:
     - estimated errors
     """
 
-    def __init__(self, timestamp: float =0.0) -> None:
+    def __init__(self, timestamp: float = 0.0, angles_calibrated: dict[int, LighthouseBsVectors] = None) -> None:
         self.timestamp: float = timestamp
-        self.angles_calibrated = {}
+
+        # Angles measured by the Crazyflie and compensated using calibration data
+        # Stored in a dictionary using base station id as the key
+        self.angles_calibrated: dict[int, LighthouseBsVectors] = angles_calibrated
+        if self.angles_calibrated is None:
+            self.angles_calibrated = {}
+
+        # Initial estimates of bs poses for this sample, in the CF reference frame
+        self.initial_est_bs_poses: dict[int, Pose] = {}
+
+        # The initial estimate of the CF pose for this sample, in the global ref frame
+        self.inital_est_pose: Pose = None
+
+
+class LhDeck4SensorPositions:
+    """ Positions of the sensors on the Lighthouse 4 deck """
+    # Sensor distances on the lighthouse deck
+    _sensor_distance_width = 0.015
+    _sensor_distance_length = 0.03
+
+    # Sensor positions in the Crazyflie reference frame
+    positions = np.float32([
+        (-_sensor_distance_length / 2, _sensor_distance_width / 2, 0.0),
+        (-_sensor_distance_length / 2, -_sensor_distance_width / 2, 0.0),
+        (_sensor_distance_length / 2, _sensor_distance_width / 2, 0.0),
+        (_sensor_distance_length / 2, -_sensor_distance_width / 2, 0.0)])

--- a/examples/lighthouse/bs_geometry_estimation.py
+++ b/examples/lighthouse/bs_geometry_estimation.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+#
+#     ||          ____  _ __
+#  +------+      / __ )(_) /_______________ _____  ___
+#  | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+#  +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#   ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+#  Copyright (C) 2022 Bitcraze AB
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA  02110-1301, USA.
+'''
+Script to run a full base station geometry estimation of a lighthouse
+system. The script records data from a Crazyflie that is moved around in
+the flight space and creates a solution that minimizes the error
+in the measured positions.
+
+The execution of the script takes you through a number of steps, please follow
+the instructions.
+
+This script supports large systems with more than 2 base stations (if
+supported by the CF firmware).
+
+This script is a temporary implementation until similar functionality has been
+added to the client.
+
+Prerequisite: The base station calibration data must have been
+received by the Crazyflie before this script is executed.
+'''
+import logging
+import time
+from threading import Event
+
+import cflib.crtp  # noqa
+from cflib.crazyflie import Crazyflie
+from cflib.crazyflie.mem import LighthouseMemHelper
+from cflib.crazyflie.mem.lighthouse_memory import LighthouseBsGeometry
+from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
+from cflib.localization.lighthouse_geometry_solver import LighthouseGeometrySolver
+from cflib.localization.lighthouse_initial_estimator import LighthouseInitialEstimator
+from cflib.localization.lighthouse_sample_matcher import LighthouseSampleMatcher
+from cflib.localization.lighthouse_sweep_angle_reader import LighthouseSweepAngleAverageReader
+from cflib.localization.lighthouse_sweep_angle_reader import LighthouseSweepAngleReader
+from cflib.localization.lighthouse_types import LhCfPoseSample
+from cflib.localization.lighthouse_types import LhDeck4SensorPositions
+from cflib.localization.lighthouse_types import LhMeasurement
+from cflib.utils import uri_helper
+
+
+def record_angles_average(scf):
+    recorded_angles = None
+
+    isReady = Event()
+
+    def ready_cb(averages):
+        nonlocal recorded_angles
+        recorded_angles = averages
+        isReady.set()
+
+    reader = LighthouseSweepAngleAverageReader(scf.cf, ready_cb)
+    reader.start_angle_collection()
+    isReady.wait()
+
+    angles_calibrated = {}
+    for bs_id, data in recorded_angles.items():
+        angles_calibrated[bs_id] = data[1]
+
+    return LhCfPoseSample(angles_calibrated=angles_calibrated)
+
+
+def record_angles_sequence(scf, recording_time_s):
+    result = []
+
+    def ready_cb(bs_id, angles):
+        now = time.time()
+        measurement = LhMeasurement(timestamp=now, base_station_id=bs_id, angles=angles)
+        result.append(measurement)
+
+    reader = LighthouseSweepAngleReader(scf.cf, ready_cb)
+    reader.start()
+    time.sleep(recording_time_s)
+    reader.stop()
+
+    return result
+
+
+def parse(recording_time, default):
+    try:
+        return int(recording_time)
+    except ValueError:
+        return default
+
+
+def estimate_geometry(origin, samples):
+    matched_samples = [origin] + LighthouseSampleMatcher.match(samples, min_nr_of_bs_in_match=2)
+    initial_guess = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
+    solution = LighthouseGeometrySolver.solve(initial_guess, matched_samples, LhDeck4SensorPositions.positions)
+
+    print('  Base stations at:')
+    for bs_id, pose in sorted(solution.bs_poses.items()):
+        pos = pose.translation
+        print(f'    {bs_id}: ({pos[0]}, {pos[1]}, {pos[2]})')
+
+    return solution.bs_poses
+
+
+def upload_geometry(scf, bs_poses):
+    geo_dict = {}
+    for bs_id, pose in bs_poses.items():
+        geo = LighthouseBsGeometry()
+        geo.origin = pose.translation.tolist()
+        geo.rotation_matrix = pose.rot_matrix.tolist()
+        geo.valid = True
+        geo_dict[bs_id] = geo
+
+    event = Event()
+
+    def data_written(success):
+        if not success:
+            raise Exception('Upload failed')
+        event.set()
+
+    helper = LighthouseMemHelper(scf.cf)
+    helper.write_geos(geo_dict, data_written)
+    event.wait()
+
+
+# Only output errors from the logging framework
+logging.basicConfig(level=logging.ERROR)
+
+if __name__ == '__main__':
+    uri = uri_helper.uri_from_env(default='radio://0/80/2M/E7E7E7E7E7')
+
+    # Initialize the low-level drivers
+    cflib.crtp.init_drivers()
+
+    print(f'Step 1. Connecting to the Crazyflie on uri {uri}...')
+    with SyncCrazyflie(uri, cf=Crazyflie(rw_cache='./cache')) as scf:
+        print('  Connected')
+        print('Step 2. Put the Crazyflie where you want the origin of your coordinate system, ' +
+              'oriented with forward in the positive X direction.')
+        input('Press return when ready. ')
+        print('  Recoding...')
+        origin = record_angles_average(scf)
+        print('  Position recorded')
+
+        print('Step 3. We will now record data from the space you plan to fly in and optimize the base station ' +
+              'geometry based on this data. Move the Crazyflie around, try to cover all of the space, make sure ' +
+              'all the base stations are received and do not move too fast. ')
+        print('This step does not add anything in a system with only one base station, enter 0 in this case.')
+        default_time = 10
+        recording_time = input(f'Enter the number of seconds you want to record ({default_time} by default), ' +
+                               'recording starts when you hit enter. ')
+        recording_time_s = parse(recording_time, default_time)
+        print('  Recording started...')
+        samples = record_angles_sequence(scf, recording_time_s)
+        print('  Recording ended')
+
+        print('Step 4. Estimating geometry...')
+        bs_poses = estimate_geometry(origin, samples)
+        print('  Geometry estimated')
+
+        print('Step 5. Upload geometry to the Crazyflie')
+        input('Press enter to upload geometry. ')
+        upload_geometry(scf, bs_poses)
+        print('Geometry uploaded')

--- a/examples/lighthouse/bs_geometry_estimation.py
+++ b/examples/lighthouse/bs_geometry_estimation.py
@@ -47,7 +47,6 @@ from threading import Event
 
 import cflib.crtp  # noqa
 from cflib.crazyflie import Crazyflie
-from cflib.crazyflie.mem import LighthouseMemHelper
 from cflib.crazyflie.mem.lighthouse_memory import LighthouseBsGeometry
 from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
 from cflib.localization.lighthouse_config_manager import LighthouseConfigWriter

--- a/examples/lighthouse/bs_geometry_estimation.py
+++ b/examples/lighthouse/bs_geometry_estimation.py
@@ -112,6 +112,9 @@ def estimate_geometry(origin, samples):
     for bs_id, pose in sorted(solution.bs_poses.items()):
         pos = pose.translation
         print(f'    {bs_id}: ({pos[0]}, {pos[1]}, {pos[2]})')
+    print('  Solution match per base station:')
+    for bs_id, value in solution.error_info['bs'].items():
+        print(f'    {bs_id}: {value}')
 
     return solution.bs_poses
 
@@ -152,7 +155,7 @@ if __name__ == '__main__':
         print('Step 2. Put the Crazyflie where you want the origin of your coordinate system, ' +
               'oriented with forward in the positive X direction.')
         input('Press return when ready. ')
-        print('  Recoding...')
+        print('  Recording...')
         origin = record_angles_average(scf)
         print('  Position recorded')
 

--- a/examples/lighthouse/bs_geometry_estimation.py
+++ b/examples/lighthouse/bs_geometry_estimation.py
@@ -121,10 +121,10 @@ def estimate_geometry(origin, x_axis, xy_plane, samples):
     print('  Base stations at:')
     for bs_id, pose in sorted(bs_aligned_poses.items()):
         pos = pose.translation
-        print(f'    {bs_id}: ({pos[0]}, {pos[1]}, {pos[2]})')
+        print(f'    {bs_id + 1}: ({pos[0]}, {pos[1]}, {pos[2]})')
     print('  Solution match per base station:')
     for bs_id, value in solution.error_info['bs'].items():
-        print(f'    {bs_id}: {value}')
+        print(f'    {bs_id + 1}: {value}')
 
     return bs_aligned_poses
 

--- a/examples/lighthouse/bs_geometry_estimation.py
+++ b/examples/lighthouse/bs_geometry_estimation.py
@@ -108,6 +108,8 @@ def estimate_geometry(origin, x_axis, xy_plane, samples):
     matched_samples = [origin] + x_axis + xy_plane + LighthouseSampleMatcher.match(samples, min_nr_of_bs_in_match=2)
     initial_guess = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
     solution = LighthouseGeometrySolver.solve(initial_guess, matched_samples, LhDeck4SensorPositions.positions)
+    if not solution.success:
+        print("Solution did not converge, it might not be good!")
 
     start_x_axis = 1
     start_xy_plane = 1 + len(x_axis)

--- a/examples/lighthouse/bs_geometry_estimation.py
+++ b/examples/lighthouse/bs_geometry_estimation.py
@@ -36,8 +36,10 @@ supported by the CF firmware).
 This script is a temporary implementation until similar functionality has been
 added to the client.
 
-Prerequisite: The base station calibration data must have been
+Prerequisite:
+1. The base station calibration data must have been
 received by the Crazyflie before this script is executed.
+2. Base stations must point downwards, towards the floor.
 '''
 import logging
 import time
@@ -48,6 +50,7 @@ from cflib.crazyflie import Crazyflie
 from cflib.crazyflie.mem import LighthouseMemHelper
 from cflib.crazyflie.mem.lighthouse_memory import LighthouseBsGeometry
 from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
+from cflib.localization.lighthouse_config_manager import LighthouseConfigWriter
 from cflib.localization.lighthouse_geometry_solver import LighthouseGeometrySolver
 from cflib.localization.lighthouse_initial_estimator import LighthouseInitialEstimator
 from cflib.localization.lighthouse_sample_matcher import LighthouseSampleMatcher
@@ -141,12 +144,10 @@ def upload_geometry(scf, bs_poses):
     event = Event()
 
     def data_written(success):
-        if not success:
-            raise Exception('Upload failed')
         event.set()
 
-    helper = LighthouseMemHelper(scf.cf)
-    helper.write_geos(geo_dict, data_written)
+    helper = LighthouseConfigWriter(scf.cf)
+    helper.write_and_store_config(data_written, geos=geo_dict)
     event.wait()
 
 
@@ -193,7 +194,8 @@ if __name__ == '__main__':
         print()
         print('Step 5. We will now record data from the space you plan to fly in and optimize the base station ' +
               'geometry based on this data. Move the Crazyflie around, try to cover all of the space, make sure ' +
-              'all the base stations are received and do not move too fast. ')
+              'all the base stations are received and do not move too fast. Make sure the Crazyflie is fairly ' +
+              'level during the recording.')
         print('This step does not add anything in a system with only one base station, enter 0 in this case.')
         default_time = 10
         recording_time = input(f'Enter the number of seconds you want to record ({default_time} by default), ' +

--- a/examples/lighthouse/bs_geometry_estimation.py
+++ b/examples/lighthouse/bs_geometry_estimation.py
@@ -17,10 +17,8 @@
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #  GNU General Public License for more details.
-#  You should have received a copy of the GNU General Public License
-#  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-#  MA  02110-1301, USA.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 '''
 Script to run a full base station geometry estimation of a lighthouse
 system. The script records data from a Crazyflie that is moved around in

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
 
     install_requires=[
         'pyusb>=1.0.0b2',
-        'opencv-python-headless~=4.5.1'
     ],
 
     # $ pip install -e .[dev]

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
 
     install_requires=[
         'pyusb>=1.0.0b2',
+        'scipy>=1.7',
     ],
 
     # $ pip install -e .[dev]

--- a/test/localization/lighthouse_fixtures.py
+++ b/test/localization/lighthouse_fixtures.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2022 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import numpy as np
+
+from cflib.localization.lighthouse_bs_vector import LighthouseBsVector
+from cflib.localization.lighthouse_bs_vector import LighthouseBsVectors
+from cflib.localization.lighthouse_types import LhDeck4SensorPositions
+from cflib.localization.lighthouse_types import Pose
+
+
+class LighthouseFixtures:
+    """
+    Fixtures to be used in lighthouse unit tests
+    """
+
+    # Stock objects
+    # BS0 is pointing along the X-axis
+    BS0_POSE = Pose(t_vec=(-2.0, 1.0, 3.0))
+    # BS1 is pointing along the Y-axis
+    BS1_POSE = Pose.from_rot_vec(R_vec=(0.0, 0.0, np.pi / 2), t_vec=(0.0, -2.0, 3.0))
+    # BS2 is pointing along the negative Y-axis
+    BS2_POSE = Pose.from_rot_vec(R_vec=(0.0, 0.0, -np.pi / 2), t_vec=(0.0, 2.0, 3.0))
+    # BS3 is pointing along the negative X-axis
+    BS3_POSE = Pose.from_rot_vec(R_vec=(0.0, 0.0, np.pi), t_vec=(2.0, 0.0, 2.0))
+
+    # CF_ORIGIN is in the origin, pointing along the X-axis
+    CF_ORIGIN_POSE = Pose()
+
+    # CF1 is pointing along the X-axis
+    CF1_POSE = Pose(t_vec=(0.3, 0.2, 0.1))
+
+    # CF2 is pointing along the Y-axis
+    CF2_POSE = Pose.from_rot_vec(R_vec=(0.0, 0.0, np.pi / 2), t_vec=(1.0, 0.0, 0.0))
+
+    def __init__(self) -> None:
+        self.angles_cf_origin_bs0 = self.synthesize_angles(self.CF_ORIGIN_POSE, self.BS0_POSE)
+        self.angles_cf_origin_bs1 = self.synthesize_angles(self.CF_ORIGIN_POSE, self.BS1_POSE)
+
+        self.angles_cf1_bs1 = self.synthesize_angles(self.CF1_POSE, self.BS1_POSE)
+        self.angles_cf1_bs2 = self.synthesize_angles(self.CF1_POSE, self.BS2_POSE)
+
+        self.angles_cf2_bs0 = self.synthesize_angles(self.CF2_POSE, self.BS0_POSE)
+        self.angles_cf2_bs1 = self.synthesize_angles(self.CF2_POSE, self.BS1_POSE)
+        self.angles_cf2_bs2 = self.synthesize_angles(self.CF2_POSE, self.BS2_POSE)
+        self.angles_cf2_bs3 = self.synthesize_angles(self.CF2_POSE, self.BS3_POSE)
+
+    def synthesize_angles(self, pose_cf: Pose, pose_bs: Pose) -> LighthouseBsVectors:
+        """
+        Genereate a LighthouseBsVectors object based
+        """
+
+        result = LighthouseBsVectors()
+        for sens_pos_ref_cf in LhDeck4SensorPositions.positions:
+            sens_pos_ref_global = pose_cf.rotate_translate(sens_pos_ref_cf)
+            sens_pos_ref_bs = pose_bs.inv_rotate_translate(sens_pos_ref_global)
+            result.append(LighthouseBsVector.from_cart(sens_pos_ref_bs))
+        return result

--- a/test/localization/lighthouse_test_base.py
+++ b/test/localization/lighthouse_test_base.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2022 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import unittest
+
+import numpy as np
+import numpy.typing as npt
+
+from cflib.localization.lighthouse_types import Pose
+
+
+class LighthouseTestBase(unittest.TestCase):
+    """
+    Utilitis to simplify testing of lighthouse code
+    """
+
+    def assertVectorsAlmostEqual(self, expected: npt.ArrayLike, actual: npt.ArrayLike, places: int = 5) -> None:
+        _expected = np.array(expected)
+        _actual = np.array(actual)
+
+        self.assertEqual(_expected.shape[0], _actual.shape[0], 'Shape differs')
+
+        for i in range(_expected.shape[0]):
+            self.assertAlmostEqual(_expected[i], _actual[i], places, f'Lists differs in element {i}')
+
+    def assertPosesAlmostEqual(self, expected: Pose, actual: Pose, places: int = 5):
+        translation_diff = expected.translation - actual.translation
+        self.assertAlmostEqual(0.0, np.linalg.norm(translation_diff), places,
+                               f'Translation different, expected: {expected.translation}, actual: {actual.translation}')
+
+        rotation_diff = expected.rot_vec - actual.rot_vec
+        self.assertAlmostEqual(0.0, np.linalg.norm(rotation_diff), places,
+                               f'Rotation different, expected: {expected.rot_vec}, actual: {actual.rot_vec}')

--- a/test/localization/lighthouse_test_base.py
+++ b/test/localization/lighthouse_test_base.py
@@ -23,6 +23,7 @@ import unittest
 
 import numpy as np
 import numpy.typing as npt
+from scipy.spatial.transform.rotation import Rotation
 
 from cflib.localization.lighthouse_types import Pose
 
@@ -46,6 +47,13 @@ class LighthouseTestBase(unittest.TestCase):
         self.assertAlmostEqual(0.0, np.linalg.norm(translation_diff), places,
                                f'Translation different, expected: {expected.translation}, actual: {actual.translation}')
 
-        rotation_diff = expected.rot_vec - actual.rot_vec
+        def un_ambiguize(rot_vec):
+            quat = Rotation.from_rotvec(expected.rot_vec).as_quat()
+            return Rotation.from_quat(quat).as_rotvec()
+
+        _expected_rot_vec = un_ambiguize(expected.rot_vec)
+        _actual_rot_vec = un_ambiguize(actual.rot_vec)
+
+        rotation_diff = _expected_rot_vec - _actual_rot_vec
         self.assertAlmostEqual(0.0, np.linalg.norm(rotation_diff), places,
                                f'Rotation different, expected: {expected.rot_vec}, actual: {actual.rot_vec}')

--- a/test/localization/lighthouse_test_base.py
+++ b/test/localization/lighthouse_test_base.py
@@ -48,7 +48,7 @@ class LighthouseTestBase(unittest.TestCase):
                                f'Translation different, expected: {expected.translation}, actual: {actual.translation}')
 
         def un_ambiguize(rot_vec):
-            quat = Rotation.from_rotvec(expected.rot_vec).as_quat()
+            quat = Rotation.from_rotvec(rot_vec).as_quat()
             return Rotation.from_quat(quat).as_rotvec()
 
         _expected_rot_vec = un_ambiguize(expected.rot_vec)

--- a/test/localization/test_ippe_cf.py
+++ b/test/localization/test_ippe_cf.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2022 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+from test.localization.lighthouse_fixtures import LighthouseFixtures
+from test.localization.lighthouse_test_base import LighthouseTestBase
+
+import numpy as np
+
+from cflib.localization.ippe_cf import IppeCf
+from cflib.localization.lighthouse_types import LhDeck4SensorPositions
+from cflib.localization.lighthouse_types import Pose
+
+
+class TestIppeCf(LighthouseTestBase):
+    def setUp(self):
+        self.fixtures = LighthouseFixtures()
+
+    def test_that_pose_is_found(self):
+        # Fixture
+        pose_bs = Pose(t_vec=(0.0, 0.0, 0.0))
+        pose_cf = Pose(t_vec=(1.0, 0.0, -1.0))
+
+        U = LhDeck4SensorPositions.positions
+        Q = self.fixtures.synthesize_angles(pose_cf, pose_bs).projection_pair_list()
+
+        # The CF pose seen from the base station
+        expected_0 = pose_cf
+
+        # Not sure if (why) this is the expected mirror solution
+        expected_1 = Pose.from_rot_vec(R_vec=(0.0, -np.pi / 2, 0.0), t_vec=pose_cf.translation)
+
+        # Test
+        actual = IppeCf.solve(U, Q)
+
+        # Assert
+        actual_pose_0 = Pose(actual[0].R, actual[0].t)
+        self.assertPosesAlmostEqual(expected_0, actual_pose_0, places=3)
+
+        actual_pose_1 = Pose(actual[1].R, actual[1].t)
+        self.assertPosesAlmostEqual(expected_1, actual_pose_1, places=3)

--- a/test/localization/test_lighthouse_bs_geo.py
+++ b/test/localization/test_lighthouse_bs_geo.py
@@ -19,62 +19,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-import math
 import unittest
 
 from cflib.localization import LighthouseBsGeoEstimator
-from cflib.localization import LighthouseBsVector
 
 
 class TestLighthouseBsGeoEstimator(unittest.TestCase):
     def setUp(self):
 
         self.sut = LighthouseBsGeoEstimator()
-
-    def test_that_initial_yaw_guess_is_correct_ba_is_behind(self):
-        # Fixture
-        bs_vectors = [
-            LighthouseBsVector(1, 0),
-            LighthouseBsVector(2, 0),
-            LighthouseBsVector(0, 0),
-            LighthouseBsVector(3, 0),
-        ]
-
-        # Test
-        actual = self.sut._find_initial_yaw_guess(bs_vectors)
-
-        # Assert
-        self.assertEqual(0.0, actual)
-
-    def test_that_initial_yaw_guess_is_correct_ba_is_front(self):
-        # Fixture 1, 3, 2, 0
-        bs_vectors = [
-            LighthouseBsVector(3, 0),
-            LighthouseBsVector(0, 0),
-            LighthouseBsVector(2, 0),
-            LighthouseBsVector(1, 0),
-        ]
-
-        # Test
-        actual = self.sut._find_initial_yaw_guess(bs_vectors)
-
-        # Assert
-        self.assertEqual(math.radians(180), actual)
-
-    def test_that_initial_yaw_guess_is_correct_bs_left_behind(self):
-        # Fixture
-        bs_vectors = [
-            LighthouseBsVector(1.0, 0),
-            LighthouseBsVector(-0.5, 0),
-            LighthouseBsVector(0.5, 0),
-            LighthouseBsVector(-1.0, 0),
-        ]
-
-        # Test
-        actual = self.sut._find_initial_yaw_guess(bs_vectors)
-
-        # Assert
-        self.assertEqual(math.radians(155), actual)
 
     def test_that_sanity_check_finds_coordinate_out_of_bounds(self):
         # Fixture

--- a/test/localization/test_lighthouse_bs_vector.py
+++ b/test/localization/test_lighthouse_bs_vector.py
@@ -19,7 +19,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-import unittest
+from test.localization.lighthouse_test_base import LighthouseTestBase
 
 import numpy as np
 
@@ -27,7 +27,7 @@ from cflib.localization import LighthouseBsVector
 from cflib.localization.lighthouse_bs_vector import LighthouseBsVectors
 
 
-class TestLighthouseBsVector(unittest.TestCase):
+class TestLighthouseBsVector(LighthouseTestBase):
     def setUp(self):
         pass
 
@@ -147,3 +147,18 @@ class TestLighthouseBsVector(unittest.TestCase):
         self.assertEqual(len(vectors), len(actual))
         self.assertListEqual(vectors[0].projection.tolist(), actual[0].tolist())
         self.assertListEqual(vectors[3].projection.tolist(), actual[3].tolist())
+
+    def test_conversion_to_angle_list(self):
+        # Fixture
+        vectors = LighthouseBsVectors((
+            LighthouseBsVector(0.0, 0.1),
+            LighthouseBsVector(0.2, 0.3),
+            LighthouseBsVector(0.4, 0.5),
+            LighthouseBsVector(0.6, 0.7),
+        ))
+
+        # Test
+        actual = vectors.angle_list()
+
+        # Assert
+        self.assertVectorsAlmostEqual((0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7), actual)

--- a/test/localization/test_lighthouse_bs_vector.py
+++ b/test/localization/test_lighthouse_bs_vector.py
@@ -24,6 +24,7 @@ import unittest
 import numpy as np
 
 from cflib.localization import LighthouseBsVector
+from cflib.localization.lighthouse_bs_vector import LighthouseBsVectors
 
 
 class TestLighthouseBsVector(unittest.TestCase):
@@ -116,3 +117,33 @@ class TestLighthouseBsVector(unittest.TestCase):
 
         # Assert
         self.assertAlmostEqual(1.0, actual)
+
+    def test_conversion_to_from_projection(self):
+        # Fixture
+        horiz = 0.123
+        vert = 0.456
+        v1 = LighthouseBsVector(horiz, vert)
+
+        # Test
+        actual = LighthouseBsVector.from_projection(v1.projection)
+
+        # Assert
+        self.assertAlmostEqual(horiz, actual.lh_v1_horiz_angle)
+        self.assertAlmostEqual(vert, actual.lh_v1_vert_angle)
+
+    def test_conversion_to_projection_pair_list(self):
+        # Fixture
+        vectors = LighthouseBsVectors((
+            LighthouseBsVector(0.0, 0.0),
+            LighthouseBsVector(0.1, 0.1),
+            LighthouseBsVector(0.2, 0.2),
+            LighthouseBsVector(0.3, 0.3),
+        ))
+
+        # Test
+        actual = vectors.projection_pair_list()
+
+        # Assert
+        self.assertEqual(len(vectors), len(actual))
+        self.assertListEqual(vectors[0].projection.tolist(), actual[0].tolist())
+        self.assertListEqual(vectors[3].projection.tolist(), actual[3].tolist())

--- a/test/localization/test_lighthouse_geometry_solver.py
+++ b/test/localization/test_lighthouse_geometry_solver.py
@@ -42,11 +42,11 @@ class TestLighthouseGeometrySolver(LighthouseTestBase):
             }),
         ]
 
-        initial_guess_bs_poses = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
+        initial_guess = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
 
         # Test
         actual = LighthouseGeometrySolver.solve(
-            initial_guess_bs_poses, matched_samples, LhDeck4SensorPositions.positions)
+            initial_guess, matched_samples, LhDeck4SensorPositions.positions)
 
         # Assert
         bs_poses = actual.bs_poses
@@ -64,11 +64,11 @@ class TestLighthouseGeometrySolver(LighthouseTestBase):
             }),
         ]
 
-        initial_guess_bs_poses = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
+        initial_guess = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
 
         # Test
         actual = LighthouseGeometrySolver.solve(
-            initial_guess_bs_poses, matched_samples, LhDeck4SensorPositions.positions)
+            initial_guess, matched_samples, LhDeck4SensorPositions.positions)
 
         # Assert
         bs_poses = actual.bs_poses
@@ -97,11 +97,11 @@ class TestLighthouseGeometrySolver(LighthouseTestBase):
             }),
         ]
 
-        initial_guess_bs_poses = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
+        initial_guess = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
 
         # Test
         actual = LighthouseGeometrySolver.solve(
-            initial_guess_bs_poses, matched_samples, LhDeck4SensorPositions.positions)
+            initial_guess, matched_samples, LhDeck4SensorPositions.positions)
 
         # Assert
         bs_poses = actual.bs_poses

--- a/test/localization/test_lighthouse_geometry_solver.py
+++ b/test/localization/test_lighthouse_geometry_solver.py
@@ -78,10 +78,10 @@ class TestLighthouseGeometrySolver(LighthouseTestBase):
     def test_that_linked_bs_poses_in_multiple_samples_are_estimated(self):
         # Fixture
         # CF_ORIGIN is used in the first sample and will define the global reference frame
-        bs_id0 = 3
-        bs_id1 = 1
-        bs_id2 = 2
-        bs_id3 = 0
+        bs_id0 = 7
+        bs_id1 = 2
+        bs_id2 = 9
+        bs_id3 = 3
         matched_samples = [
             LhCfPoseSample(angles_calibrated={
                 bs_id0: self.fixtures.angles_cf_origin_bs0,

--- a/test/localization/test_lighthouse_geometry_solver.py
+++ b/test/localization/test_lighthouse_geometry_solver.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2022 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+from test.localization.lighthouse_fixtures import LighthouseFixtures
+from test.localization.lighthouse_test_base import LighthouseTestBase
+
+from cflib.localization.lighthouse_geometry_solver import LighthouseGeometrySolver
+from cflib.localization.lighthouse_initial_estimator import LighthouseInitialEstimator
+from cflib.localization.lighthouse_types import LhCfPoseSample
+from cflib.localization.lighthouse_types import LhDeck4SensorPositions
+
+
+class TestLighthouseGeometrySolver(LighthouseTestBase):
+    def setUp(self):
+        self.fixtures = LighthouseFixtures()
+
+    def test_that_one_bs_poses_in_one_sample_is_estimated(self):
+        # Fixture
+        # CF_ORIGIN is used in the first sample and will define the global reference frame
+        bs_id0 = 3
+        matched_samples = [
+            LhCfPoseSample(angles_calibrated={
+                bs_id0: self.fixtures.angles_cf_origin_bs0,
+            }),
+        ]
+
+        initial_guess_bs_poses = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
+
+        # Test
+        actual = LighthouseGeometrySolver.solve(
+            initial_guess_bs_poses, matched_samples, LhDeck4SensorPositions.positions)
+
+        # Assert
+        bs_poses = actual.bs_poses
+        self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, bs_poses[bs_id0], places=3)
+
+    def test_that_two_bs_poses_in_one_sample_are_estimated(self):
+        # Fixture
+        # CF_ORIGIN is used in the first sample and will define the global reference frame
+        bs_id0 = 3
+        bs_id1 = 1
+        matched_samples = [
+            LhCfPoseSample(angles_calibrated={
+                bs_id0: self.fixtures.angles_cf_origin_bs0,
+                bs_id1: self.fixtures.angles_cf_origin_bs1,
+            }),
+        ]
+
+        initial_guess_bs_poses = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
+
+        # Test
+        actual = LighthouseGeometrySolver.solve(
+            initial_guess_bs_poses, matched_samples, LhDeck4SensorPositions.positions)
+
+        # Assert
+        bs_poses = actual.bs_poses
+        self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, bs_poses[bs_id0], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS1_POSE, bs_poses[bs_id1], places=3)
+
+    def test_that_linked_bs_poses_in_multiple_samples_are_estimated(self):
+        # Fixture
+        # CF_ORIGIN is used in the first sample and will define the global reference frame
+        bs_id0 = 3
+        bs_id1 = 1
+        bs_id2 = 2
+        bs_id3 = 0
+        matched_samples = [
+            LhCfPoseSample(angles_calibrated={
+                bs_id0: self.fixtures.angles_cf_origin_bs0,
+                bs_id1: self.fixtures.angles_cf_origin_bs1,
+            }),
+            LhCfPoseSample(angles_calibrated={
+                bs_id1: self.fixtures.angles_cf1_bs1,
+                bs_id2: self.fixtures.angles_cf1_bs2,
+            }),
+            LhCfPoseSample(angles_calibrated={
+                bs_id2: self.fixtures.angles_cf2_bs2,
+                bs_id3: self.fixtures.angles_cf2_bs3,
+            }),
+        ]
+
+        initial_guess_bs_poses = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
+
+        # Test
+        actual = LighthouseGeometrySolver.solve(
+            initial_guess_bs_poses, matched_samples, LhDeck4SensorPositions.positions)
+
+        # Assert
+        bs_poses = actual.bs_poses
+        self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, bs_poses[bs_id0], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS1_POSE, bs_poses[bs_id1], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS2_POSE, bs_poses[bs_id2], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS3_POSE, bs_poses[bs_id3], places=3)

--- a/test/localization/test_lighthouse_initial_estimator.py
+++ b/test/localization/test_lighthouse_initial_estimator.py
@@ -46,7 +46,7 @@ class TestLighthouseInitialEstimator(LighthouseTestBase):
         actual = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
 
         # Assert
-        self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, actual[bs_id], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, actual.bs_poses[bs_id], places=3)
 
     def test_that_two_bs_poses_in_same_sample_are_found(self):
         # Fixture
@@ -64,15 +64,15 @@ class TestLighthouseInitialEstimator(LighthouseTestBase):
         actual = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
 
         # Assert
-        self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, actual[bs_id0], places=3)
-        self.assertPosesAlmostEqual(self.fixtures.BS1_POSE, actual[bs_id1], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, actual.bs_poses[bs_id0], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS1_POSE, actual.bs_poses[bs_id1], places=3)
 
     def test_that_linked_bs_poses_in_multiple_samples_are_found(self):
         # Fixture
         # CF_ORIGIN is used in the first sample and will define the global reference frame
-        bs_id0 = 3
+        bs_id0 = 7
         bs_id1 = 1
-        bs_id2 = 2
+        bs_id2 = 5
         bs_id3 = 0
         samples = [
             LhCfPoseSample(angles_calibrated={
@@ -93,10 +93,40 @@ class TestLighthouseInitialEstimator(LighthouseTestBase):
         actual = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
 
         # Assert
-        self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, actual[bs_id0], places=3)
-        self.assertPosesAlmostEqual(self.fixtures.BS1_POSE, actual[bs_id1], places=3)
-        self.assertPosesAlmostEqual(self.fixtures.BS2_POSE, actual[bs_id2], places=3)
-        self.assertPosesAlmostEqual(self.fixtures.BS3_POSE, actual[bs_id3], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, actual.bs_poses[bs_id0], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS1_POSE, actual.bs_poses[bs_id1], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS2_POSE, actual.bs_poses[bs_id2], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS3_POSE, actual.bs_poses[bs_id3], places=3)
+
+    def test_that_cf_poses_are_estimated(self):
+        # Fixture
+        # CF_ORIGIN is used in the first sample and will define the global reference frame
+        bs_id0 = 7
+        bs_id1 = 1
+        bs_id2 = 5
+        bs_id3 = 0
+        samples = [
+            LhCfPoseSample(angles_calibrated={
+                bs_id0: self.fixtures.angles_cf_origin_bs0,
+                bs_id1: self.fixtures.angles_cf_origin_bs1,
+            }),
+            LhCfPoseSample(angles_calibrated={
+                bs_id1: self.fixtures.angles_cf1_bs1,
+                bs_id2: self.fixtures.angles_cf1_bs2,
+            }),
+            LhCfPoseSample(angles_calibrated={
+                bs_id2: self.fixtures.angles_cf2_bs2,
+                bs_id3: self.fixtures.angles_cf2_bs3,
+            }),
+        ]
+
+        # Test
+        actual = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
+
+        # Assert
+        self.assertPosesAlmostEqual(self.fixtures.CF_ORIGIN_POSE, actual.cf_poses[0], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.CF1_POSE, actual.cf_poses[1], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.CF2_POSE, actual.cf_poses[2], places=3)
 
     def test_that_the_global_ref_frame_is_used(self):
         # Fixture
@@ -120,11 +150,11 @@ class TestLighthouseInitialEstimator(LighthouseTestBase):
 
         # Assert
         self.assertPosesAlmostEqual(
-            Pose.from_rot_vec(R_vec=(0.0, 0.0, -np.pi / 2), t_vec=(1.0, 3.0, 3.0)), actual[bs_id0], places=3)
+            Pose.from_rot_vec(R_vec=(0.0, 0.0, -np.pi / 2), t_vec=(1.0, 3.0, 3.0)), actual.bs_poses[bs_id0], places=3)
         self.assertPosesAlmostEqual(
-            Pose.from_rot_vec(R_vec=(0.0, 0.0, 0.0), t_vec=(-2.0, 1.0, 3.0)), actual[bs_id1], places=3)
+            Pose.from_rot_vec(R_vec=(0.0, 0.0, 0.0), t_vec=(-2.0, 1.0, 3.0)), actual.bs_poses[bs_id1], places=3)
         self.assertPosesAlmostEqual(
-            Pose.from_rot_vec(R_vec=(0.0, 0.0, np.pi), t_vec=(2.0, 1.0, 3.0)), actual[bs_id2], places=3)
+            Pose.from_rot_vec(R_vec=(0.0, 0.0, np.pi), t_vec=(2.0, 1.0, 3.0)), actual.bs_poses[bs_id2], places=3)
 
     def test_that_raises_for_isolated_bs(self):
         # Fixture

--- a/test/localization/test_lighthouse_initial_estimator.py
+++ b/test/localization/test_lighthouse_initial_estimator.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2022 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+from test.localization.lighthouse_fixtures import LighthouseFixtures
+from test.localization.lighthouse_test_base import LighthouseTestBase
+
+import numpy as np
+
+from cflib.localization.lighthouse_initial_estimator import LighthouseInitialEstimator
+from cflib.localization.lighthouse_types import LhCfPoseSample
+from cflib.localization.lighthouse_types import LhDeck4SensorPositions
+from cflib.localization.lighthouse_types import Pose
+
+
+class TestLighthouseInitialEstimator(LighthouseTestBase):
+    def setUp(self):
+        self.fixtures = LighthouseFixtures()
+
+    def test_that_one_bs_pose_is_found(self):
+        # Fixture
+        # CF_ORIGIN is used in the first sample and will define the global reference frame
+        bs_id = 3
+        samples = [
+            LhCfPoseSample(angles_calibrated={bs_id: self.fixtures.angles_cf_origin_bs0}),
+        ]
+
+        # Test
+        actual = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
+
+        # Assert
+        self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, actual[bs_id], places=3)
+
+    def test_that_two_bs_poses_in_same_sample_are_found(self):
+        # Fixture
+        # CF_ORIGIN is used in the first sample and will define the global reference frame
+        bs_id0 = 3
+        bs_id1 = 1
+        samples = [
+            LhCfPoseSample(angles_calibrated={
+                bs_id0: self.fixtures.angles_cf_origin_bs0,
+                bs_id1: self.fixtures.angles_cf_origin_bs1,
+            }),
+        ]
+
+        # Test
+        actual = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
+
+        # Assert
+        self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, actual[bs_id0], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS1_POSE, actual[bs_id1], places=3)
+
+    def test_that_linked_bs_poses_in_multiple_samples_are_found(self):
+        # Fixture
+        # CF_ORIGIN is used in the first sample and will define the global reference frame
+        bs_id0 = 3
+        bs_id1 = 1
+        bs_id2 = 2
+        bs_id3 = 0
+        samples = [
+            LhCfPoseSample(angles_calibrated={
+                bs_id0: self.fixtures.angles_cf_origin_bs0,
+                bs_id1: self.fixtures.angles_cf_origin_bs1,
+            }),
+            LhCfPoseSample(angles_calibrated={
+                bs_id1: self.fixtures.angles_cf1_bs1,
+                bs_id2: self.fixtures.angles_cf1_bs2,
+            }),
+            LhCfPoseSample(angles_calibrated={
+                bs_id2: self.fixtures.angles_cf2_bs2,
+                bs_id3: self.fixtures.angles_cf2_bs3,
+            }),
+        ]
+
+        # Test
+        actual = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
+
+        # Assert
+        self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, actual[bs_id0], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS1_POSE, actual[bs_id1], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS2_POSE, actual[bs_id2], places=3)
+        self.assertPosesAlmostEqual(self.fixtures.BS3_POSE, actual[bs_id3], places=3)
+
+    def test_that_the_global_ref_frame_is_used(self):
+        # Fixture
+        # CF2 is used in the first sample and will define the global reference frame
+        bs_id0 = 3
+        bs_id1 = 1
+        bs_id2 = 2
+        samples = [
+            LhCfPoseSample(angles_calibrated={
+                bs_id0: self.fixtures.angles_cf2_bs0,
+                bs_id1: self.fixtures.angles_cf2_bs1,
+            }),
+            LhCfPoseSample(angles_calibrated={
+                bs_id1: self.fixtures.angles_cf1_bs1,
+                bs_id2: self.fixtures.angles_cf1_bs2,
+            }),
+        ]
+
+        # Test
+        actual = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
+
+        # Assert
+        self.assertPosesAlmostEqual(
+            Pose.from_rot_vec(R_vec=(0.0, 0.0, -np.pi / 2), t_vec=(1.0, 3.0, 3.0)), actual[bs_id0], places=3)
+        self.assertPosesAlmostEqual(
+            Pose.from_rot_vec(R_vec=(0.0, 0.0, 0.0), t_vec=(-2.0, 1.0, 3.0)), actual[bs_id1], places=3)
+        self.assertPosesAlmostEqual(
+            Pose.from_rot_vec(R_vec=(0.0, 0.0, np.pi), t_vec=(2.0, 1.0, 3.0)), actual[bs_id2], places=3)
+
+    def test_that_raises_for_isolated_bs(self):
+        # Fixture
+        bs_id0 = 3
+        bs_id1 = 1
+        bs_id2 = 2
+        samples = [
+            LhCfPoseSample(angles_calibrated={
+                bs_id0: self.fixtures.angles_cf_origin_bs0,
+                bs_id1: self.fixtures.angles_cf_origin_bs1,
+            }),
+            LhCfPoseSample(angles_calibrated={
+                bs_id2: self.fixtures.angles_cf1_bs2,
+            }),
+        ]
+
+        # Test
+        # Assert
+        with self.assertRaises(Exception):
+            LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)

--- a/test/localization/test_lighthouse_sample_matcher.py
+++ b/test/localization/test_lighthouse_sample_matcher.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2021 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import unittest
+from cflib.localization.lighthouse_bs_vector import LighthouseBsVector
+
+from cflib.localization.lighthouse_sample_matcher import LighthouseSampleMatcher
+from cflib.localization.lighthouse_types import LhMeasurement
+
+class TestLighthouseSampleMatcher(unittest.TestCase):
+    def setUp(self):
+        self.vec0 = LighthouseBsVector(0.0, 0.0)
+        self.vec1 = LighthouseBsVector(0.1, 0.1)
+        self.vec2 = LighthouseBsVector(0.2, 0.2)
+        self.vec3 = LighthouseBsVector(0.3, 0.3)
+
+        self.samples = [
+            LhMeasurement(timestamp=1.000, base_station_id=0, angles=self.vec0),
+            LhMeasurement(timestamp=1.015, base_station_id=1, angles=self.vec1),
+            LhMeasurement(timestamp=1.020, base_station_id=0, angles=self.vec2),
+            LhMeasurement(timestamp=1.035, base_station_id=1, angles=self.vec3),
+        ]
+
+
+    def test_that_samples_are_aggregated(self):
+        # Fixture
+
+        # Test
+        actual = LighthouseSampleMatcher.match(self.samples, max_time_diff=0.010)
+
+        # Assert
+        self.assertEqual(1.000, actual[0].timestamp)
+        self.assertEqual(1, len(actual[0].angles_calibrated))
+        self.assertEqual(self.vec0, actual[0].angles_calibrated[0])
+
+        self.assertEqual(1.015, actual[1].timestamp)
+        self.assertEqual(2, len(actual[1].angles_calibrated))
+        self.assertEqual(self.vec1, actual[1].angles_calibrated[1])
+        self.assertEqual(self.vec2, actual[1].angles_calibrated[0])
+
+        self.assertEqual(1.035, actual[2].timestamp)
+        self.assertEqual(1, len(actual[2].angles_calibrated))
+        self.assertEqual(self.vec3, actual[2].angles_calibrated[1])
+
+    def test_that_single_bs_samples_are_fitered(self):
+        # Fixture
+
+        # Test
+        actual = LighthouseSampleMatcher.match(self.samples, max_time_diff=0.010, min_nr_of_bs_in_match=1)
+
+        # Assert
+        self.assertEqual(1.015, actual[0].timestamp)
+        self.assertEqual(2, len(actual[0].angles_calibrated))
+        self.assertEqual(self.vec1, actual[0].angles_calibrated[1])
+        self.assertEqual(self.vec2, actual[0].angles_calibrated[0])

--- a/test/localization/test_lighthouse_sample_matcher.py
+++ b/test/localization/test_lighthouse_sample_matcher.py
@@ -20,10 +20,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 import unittest
-from cflib.localization.lighthouse_bs_vector import LighthouseBsVector
 
+from cflib.localization.lighthouse_bs_vector import LighthouseBsVector
 from cflib.localization.lighthouse_sample_matcher import LighthouseSampleMatcher
 from cflib.localization.lighthouse_types import LhMeasurement
+
 
 class TestLighthouseSampleMatcher(unittest.TestCase):
     def setUp(self):
@@ -38,7 +39,6 @@ class TestLighthouseSampleMatcher(unittest.TestCase):
             LhMeasurement(timestamp=1.020, base_station_id=0, angles=self.vec2),
             LhMeasurement(timestamp=1.035, base_station_id=1, angles=self.vec3),
         ]
-
 
     def test_that_samples_are_aggregated(self):
         # Fixture

--- a/test/localization/test_lighthouse_sample_matcher.py
+++ b/test/localization/test_lighthouse_sample_matcher.py
@@ -60,14 +60,23 @@ class TestLighthouseSampleMatcher(unittest.TestCase):
         self.assertEqual(1, len(actual[2].angles_calibrated))
         self.assertEqual(self.vec3, actual[2].angles_calibrated[1])
 
-    def test_that_single_bs_samples_are_fitered(self):
+    def test_that_single_bs_samples_are_fitered_out(self):
         # Fixture
 
         # Test
-        actual = LighthouseSampleMatcher.match(self.samples, max_time_diff=0.010, min_nr_of_bs_in_match=1)
+        actual = LighthouseSampleMatcher.match(self.samples, max_time_diff=0.010, min_nr_of_bs_in_match=2)
 
         # Assert
         self.assertEqual(1.015, actual[0].timestamp)
         self.assertEqual(2, len(actual[0].angles_calibrated))
         self.assertEqual(self.vec1, actual[0].angles_calibrated[1])
         self.assertEqual(self.vec2, actual[0].angles_calibrated[0])
+
+    def test_that_empty_sample_list_works(self):
+        # Fixture
+
+        # Test
+        actual = LighthouseSampleMatcher.match([])
+
+        # Assert
+        self.assertEqual(0, len(actual))

--- a/test/localization/test_lighthouse_system_aligner.py
+++ b/test/localization/test_lighthouse_system_aligner.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2022 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import numpy as np
+from cflib.localization.lighthouse_system_aligner import LighthouseSystemAligner
+from cflib.localization.lighthouse_types import Pose
+from test.localization.lighthouse_test_base import LighthouseTestBase
+
+
+class TestLighthouseSystemAligner(LighthouseTestBase):
+    def setUp(self):
+        pass
+
+    def test_that_transformation_is_found_for_single_points(self):
+        # Fixture
+        origin = (1.0, 0.0, 0.0)
+        x_axis = [(1.0, 1.0, 0.0)]
+        xy_plane = [(2.0, 1.0, 0.0)]
+
+        # Test
+        actual = LighthouseSystemAligner.find_transformation(origin, x_axis, xy_plane)
+
+        # Assert
+        self.assertVectorsAlmostEqual((0.0, 0.0, 0.0), actual.rotate_translate((1.0, 0.0, 0.0)))
+        self.assertVectorsAlmostEqual((1.0, 0.0, 0.0), actual.rotate_translate((1.0, 1.0, 0.0)))
+        self.assertVectorsAlmostEqual((0.0, 1.0, 0.0), actual.rotate_translate((0.0, 0.0, 0.0)))
+        self.assertVectorsAlmostEqual((0.0, 0.0, 1.0), actual.rotate_translate((1.0, 0.0, 1.0)))
+
+    def test_that_transformation_is_found_for_multiple_points(self):
+        # Fixture
+        origin = (1.0, 0.0, 0.0)
+        x_axis = [(1.0, 1.0, 0.0), (1.0, 4.0, 0.0)]
+        xy_plane = [(2.0, 1.0, 0.0), (3.0, -1.0, 0.0), (5.0, 0.0, 0.0)]
+
+        # Test
+        actual = LighthouseSystemAligner.find_transformation(origin, x_axis, xy_plane)
+
+        # Assert
+        self.assertVectorsAlmostEqual((0.0, 0.0, 0.0), actual.rotate_translate((1.0, 0.0, 0.0)))
+        self.assertVectorsAlmostEqual((1.0, 0.0, 0.0), actual.rotate_translate((1.0, 1.0, 0.0)))
+        self.assertVectorsAlmostEqual((0.0, 1.0, 0.0), actual.rotate_translate((0.0, 0.0, 0.0)))
+        self.assertVectorsAlmostEqual((0.0, 0.0, 1.0), actual.rotate_translate((1.0, 0.0, 1.0)))
+
+    def test_that_base_stations_are_rotated(self):
+        # Fixture
+        origin = (1.0, 0.0, 0.0)
+        x_axis = [(1.0, 1.0, 0.0)]
+        xy_plane = [(2.0, 1.0, 0.0)]
+
+        bs_id = 7
+        bs_poses = {bs_id: Pose.from_rot_vec(t_vec=(1.0, 0.0, 1.0))}
+
+        # Test
+        actual = LighthouseSystemAligner.align(origin, x_axis, xy_plane, bs_poses)
+
+        # Assert
+        self.assertPosesAlmostEqual(Pose.from_rot_vec(R_vec=(0.0, 0.0, -np.pi / 2), t_vec=(0.0, 0.0, 1.0)), actual[bs_id])
+
+    def test_that_solution_is_de_flipped(self):
+        # Fixture
+        origin = (0.0, 0.0, 0.0)
+        x_axis = [(-1.0, 0.0, 0.0)]
+        xy_plane = [(2.0, 1.0, 0.0)]
+
+        bs_id = 7
+        bs_poses = {bs_id: Pose.from_rot_vec(t_vec=(0.0, 0.0, 1.0))}
+        expected = Pose.from_rot_vec(R_vec=(0.0, 0.0, np.pi), t_vec=(0.0, 0.0, 1.0))
+
+        # Test
+        actual = LighthouseSystemAligner.align(origin, x_axis, xy_plane, bs_poses)
+
+        # Assert
+        self.assertPosesAlmostEqual(expected, actual[bs_id])

--- a/test/localization/test_lighthouse_system_aligner.py
+++ b/test/localization/test_lighthouse_system_aligner.py
@@ -38,10 +38,11 @@ class TestLighthouseSystemAligner(LighthouseTestBase):
         xy_plane = [(2.0, 1.0, 0.0)]
 
         # Test
-        actual = LighthouseSystemAligner.find_transformation(origin, x_axis, xy_plane)
+        actual = LighthouseSystemAligner._find_transformation(origin, x_axis, xy_plane)
 
         # Assert
         self.assertVectorsAlmostEqual((0.0, 0.0, 0.0), actual.rotate_translate((1.0, 0.0, 0.0)))
+
         self.assertVectorsAlmostEqual((1.0, 0.0, 0.0), actual.rotate_translate((1.0, 1.0, 0.0)))
         self.assertVectorsAlmostEqual((0.0, 1.0, 0.0), actual.rotate_translate((0.0, 0.0, 0.0)))
         self.assertVectorsAlmostEqual((0.0, 0.0, 1.0), actual.rotate_translate((1.0, 0.0, 1.0)))
@@ -53,10 +54,11 @@ class TestLighthouseSystemAligner(LighthouseTestBase):
         xy_plane = [(2.0, 1.0, 0.0), (3.0, -1.0, 0.0), (5.0, 0.0, 0.0)]
 
         # Test
-        actual = LighthouseSystemAligner.find_transformation(origin, x_axis, xy_plane)
+        actual = LighthouseSystemAligner._find_transformation(origin, x_axis, xy_plane)
 
         # Assert
         self.assertVectorsAlmostEqual((0.0, 0.0, 0.0), actual.rotate_translate((1.0, 0.0, 0.0)))
+
         self.assertVectorsAlmostEqual((1.0, 0.0, 0.0), actual.rotate_translate((1.0, 1.0, 0.0)))
         self.assertVectorsAlmostEqual((0.0, 1.0, 0.0), actual.rotate_translate((0.0, 0.0, 0.0)))
         self.assertVectorsAlmostEqual((0.0, 0.0, 1.0), actual.rotate_translate((1.0, 0.0, 1.0)))
@@ -92,3 +94,24 @@ class TestLighthouseSystemAligner(LighthouseTestBase):
 
         # Assert
         self.assertPosesAlmostEqual(expected, actual[bs_id])
+
+    def test_that_is_aligned_for_multiple_points_where_system_is_rotated_and_poins_are_fuzzy(self):
+        # Fixture
+        origin = (0.0, 0.0, 0.0)
+        x_axis = [(-1.0, 0.0 + 0.01, 0.0), (-2.0, 0.0 - 0.02, 0.0)]
+        xy_plane = [(2.0, 2.0, 0.0 + 0.02), (-3.0, -2.0, 0.0 + 0.01), (5.0, 0.0, 0.0 - 0.01)]
+
+        # Note: Z of base stations must be positive (above the floor)
+        bs_poses = {
+            1: Pose.from_rot_vec(t_vec=(1.0, 0.0, 1.0)),
+            2: Pose.from_rot_vec(t_vec=(0.0, 1.0, 1.0)),
+            3: Pose.from_rot_vec(t_vec=(0.0, 0.0, 1.0)),
+        }
+
+        # Test
+        actual = LighthouseSystemAligner.align(origin, x_axis, xy_plane, bs_poses)
+
+        # Assert
+        self.assertVectorsAlmostEqual((-1.0, 0.0, 1.0), actual[1].translation, places=1)
+        self.assertVectorsAlmostEqual((0.0, -1.0, 1.0), actual[2].translation, places=1)
+        self.assertVectorsAlmostEqual((0.0, 0.0, 1.0), actual[3].translation, places=1)

--- a/test/localization/test_lighthouse_system_aligner.py
+++ b/test/localization/test_lighthouse_system_aligner.py
@@ -19,10 +19,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
+from test.localization.lighthouse_test_base import LighthouseTestBase
+
 import numpy as np
+
 from cflib.localization.lighthouse_system_aligner import LighthouseSystemAligner
 from cflib.localization.lighthouse_types import Pose
-from test.localization.lighthouse_test_base import LighthouseTestBase
 
 
 class TestLighthouseSystemAligner(LighthouseTestBase):
@@ -72,7 +74,8 @@ class TestLighthouseSystemAligner(LighthouseTestBase):
         actual = LighthouseSystemAligner.align(origin, x_axis, xy_plane, bs_poses)
 
         # Assert
-        self.assertPosesAlmostEqual(Pose.from_rot_vec(R_vec=(0.0, 0.0, -np.pi / 2), t_vec=(0.0, 0.0, 1.0)), actual[bs_id])
+        self.assertPosesAlmostEqual(Pose.from_rot_vec(
+            R_vec=(0.0, 0.0, -np.pi / 2), t_vec=(0.0, 0.0, 1.0)), actual[bs_id])
 
     def test_that_solution_is_de_flipped(self):
         # Fixture

--- a/test/localization/test_lighthouse_types.py
+++ b/test/localization/test_lighthouse_types.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2022 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+import unittest
+
+import numpy as np
+
+from cflib.localization.lighthouse_types import Pose
+
+
+class TestLighthouseTypes(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_default_matrix_constructor(self):
+        # Fixture
+        # Test
+        actual = Pose()
+
+        # Assert
+        self.assertEqual(0.0, np.linalg.norm(actual.translation))
+        self.assertEqual(0.0, np.linalg.norm(actual.rot_matrix - np.identity(3)))
+
+    def test_default_rot_vec_constructor(self):
+        # Fixture
+        # Test
+        actual = Pose.from_rot_vec()
+
+        # Assert
+        self.assertEqual(0.0, np.linalg.norm(actual.translation))
+        self.assertEqual(0.0, np.linalg.norm(actual.rot_matrix - np.identity(3)))
+
+    def test_rotate_translate(self):
+        # Fixture
+        pose = Pose.from_rot_vec(R_vec=(0.0, 0.0, np.pi / 2), t_vec=(1.0, 0.0, 0.0))
+        point = (2.0, 0.0, 0.0)
+
+        # Test
+        actual = pose.rotate_translate(point)
+
+        # Assert
+        self.assertAlmostEqual(1.0, actual[0])
+        self.assertAlmostEqual(2.0, actual[1])
+        self.assertAlmostEqual(0.0, actual[2])
+
+    def test_rotate_translate_and_back(self):
+        # Fixture
+        pose = Pose.from_rot_vec(R_vec=(1.0, 2.0, 3.0), t_vec=(0.1, 0.2, 0.3))
+        expected = (2.0, 3.0, 4.0)
+
+        # Test
+        actual = pose.inv_rotate_translate(pose.rotate_translate(expected))
+
+        # Assert
+        self.assertAlmostEqual(expected[0], actual[0])
+        self.assertAlmostEqual(expected[1], actual[1])
+        self.assertAlmostEqual(expected[2], actual[2])

--- a/test/localization/test_lighthouse_types.py
+++ b/test/localization/test_lighthouse_types.py
@@ -19,14 +19,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-import unittest
+from test.localization.lighthouse_test_base import LighthouseTestBase
 
 import numpy as np
 
 from cflib.localization.lighthouse_types import Pose
 
 
-class TestLighthouseTypes(unittest.TestCase):
+class TestLighthouseTypes(LighthouseTestBase):
     def setUp(self):
         pass
 
@@ -50,11 +50,11 @@ class TestLighthouseTypes(unittest.TestCase):
 
     def test_rotate_translate(self):
         # Fixture
-        pose = Pose.from_rot_vec(R_vec=(0.0, 0.0, np.pi / 2), t_vec=(1.0, 0.0, 0.0))
+        transform = Pose.from_rot_vec(R_vec=(0.0, 0.0, np.pi / 2), t_vec=(1.0, 0.0, 0.0))
         point = (2.0, 0.0, 0.0)
 
         # Test
-        actual = pose.rotate_translate(point)
+        actual = transform.rotate_translate(point)
 
         # Assert
         self.assertAlmostEqual(1.0, actual[0])
@@ -63,13 +63,36 @@ class TestLighthouseTypes(unittest.TestCase):
 
     def test_rotate_translate_and_back(self):
         # Fixture
-        pose = Pose.from_rot_vec(R_vec=(1.0, 2.0, 3.0), t_vec=(0.1, 0.2, 0.3))
+        transform = Pose.from_rot_vec(R_vec=(1.0, 2.0, 3.0), t_vec=(0.1, 0.2, 0.3))
         expected = (2.0, 3.0, 4.0)
 
         # Test
-        actual = pose.inv_rotate_translate(pose.rotate_translate(expected))
+        actual = transform.inv_rotate_translate(transform.rotate_translate(expected))
 
         # Assert
         self.assertAlmostEqual(expected[0], actual[0])
         self.assertAlmostEqual(expected[1], actual[1])
         self.assertAlmostEqual(expected[2], actual[2])
+
+    def test_rotate_translate_pose(self):
+        # Fixture
+        transform = Pose.from_rot_vec(R_vec=(0.0, 0.0, np.pi / 2), t_vec=(1.0, 0.0, 0.0))
+        pose = Pose(t_vec=(2.0, 0.0, 0.0))
+        expected = Pose.from_rot_vec(R_vec=(0.0, 0.0, np.pi / 2), t_vec=(1.0, 2.0, 0.0))
+
+        # Test
+        actual = transform.rotate_translate_pose(pose)
+
+        # Assert
+        self.assertPosesAlmostEqual(expected, actual)
+
+    def test_rotate_translate_pose_and_back(self):
+        # Fixture
+        transform = Pose.from_rot_vec(R_vec=(1.0, 2.0, 3.0), t_vec=(0.1, 0.2, 0.3))
+        expected = Pose(t_vec=(2.0, 3.0, 4.0))
+
+        # Test
+        actual = transform.inv_rotate_translate_pose(transform.rotate_translate_pose(expected))
+
+        # Assert
+        self.assertPosesAlmostEqual(expected, actual)


### PR DESCRIPTION
This pull request adds improved base station geometry estimation to the lighthouse system. It supports more than 2 base stations (if supported by the firmware) as well as better alignment of the coordinate system. A side effect of the process is also a measurement of the errors in the solution (how good the estimated geometry is).

The new solution requires measurements with a Crazyflie in the flight space and a script has been added to the examples (examples/lighthouse/bs_geometry_estimation.py), to do a full geometry estimation and upload it to a Crazyflie. The script displays instructions and will hopefully be useful for now. The client should be updated to support the full process, until then the new implementation is compatible with the current client (but with limited functionality).

Open CV is not needed any more and the dependency has been removed. A new dependency to scipy has been added instead.

There are some issues that need to be solved to make the code work with the build tools: 
* I think I used type hint features that were introduced in python 3.8 and we currently support older versions. How to handle this?
* I use numpy.typing which currently is not supported by the builder docker image.

The PR is pretty massive, let's discuss if we want to split it up