### PR TITLE
Bump minimum Python version to 3.7

### DIFF
--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -17,10 +17,10 @@ jobs:
       - name: install lib
         run: pip install -e .
 
-  minimum-python:
+  minimum-python37:
     runs-on: ubuntu-latest
     container:
-      image: python:3.6
+      image: python:3.7
 
     steps:
       - uses: actions/checkout@v2

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -3,6 +3,12 @@ title: Installation
 page_id: install
 ---
 
+## Requirements
+
+This project requires Python 3.7+.
+For Ubuntu it means that Ubuntu 20.04+ is supported unless a more recent version of Python is installed.
+
+See bellow sections for more platform-specific requirements.
 ## Development
 ### Developing for the cflib
 * [Fork the cflib](https://help.github.com/articles/fork-a-repo/)
@@ -12,7 +18,7 @@ page_id: install
 
 * [Uninstall the cflib if you don't want it any more](http://pip-python3.readthedocs.org/en/latest/reference/pip_uninstall.html), `pip uninstall cflib`
 
-Note: If you are developing for the cflib you must use python3. On Ubuntu (16.04, 18.08) use `pip3` instead of `pip`.
+Note: If you are developing for the cflib you must use python3. On Ubuntu (20.04+) use `pip3` instead of `pip`.
 
 ### Linux, OSX, Windows
 

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -6,9 +6,7 @@ page_id: install
 ## Requirements
 
 This project requires Python 3.7+.
-For Ubuntu it means that Ubuntu 20.04+ is supported unless a more recent version of Python is installed.
-
-See bellow sections for more platform-specific requirements.
+See below sections for more platform-specific requirements.
 ## Development
 ### Developing for the cflib
 * [Fork the cflib](https://help.github.com/articles/fork-a-repo/)


### PR DESCRIPTION
This is required because of dependencies requirering Python 3.7.

Python 3.6 is not officialy supported by python.org anymore.

This breaks support for stock Ubuntu 18.04 which should not be a big issue since we are so far in the current Ubuntu LTS 20.04 and very close to the next 22.04.

Documentation has been updated to contain the minimum supported python version.