### PR TITLE
Various fixes to OW example

### DIFF
--- a/cflib/crazyflie/mem/ow_element.py
+++ b/cflib/crazyflie/mem/ow_element.py
@@ -19,7 +19,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-import array
 import logging
 import struct
 from binascii import crc32
@@ -134,7 +133,7 @@ class OWElement(MemoryElement):
         self._write_finished_cb = write_finished_cb
 
     def erase(self, write_finished_cb):
-        erase_data = array('B', [0xFF] * 112)
+        erase_data = bytes([0xFF] * 112)
         self.mem_handler.write(self, 0x00,
                                struct.unpack('B' * len(erase_data),
                                              erase_data))

--- a/examples/memory/erase-ow.py
+++ b/examples/memory/erase-ow.py
@@ -122,9 +122,6 @@ class EEPROMExample:
 
 
 if __name__ == '__main__':
-    print('This example will not work with the BLE version of the nRF51'
-          ' firmware (flashed on production units). See https://github.com'
-          '/bitcraze/crazyflie-clients-python/issues/166')
     # Initialize the low-level drivers
     cflib.crtp.init_drivers()
 

--- a/examples/memory/write-ow.py
+++ b/examples/memory/write-ow.py
@@ -73,13 +73,14 @@ class WriteOwExample:
             print('Writing test configuration to'
                   ' memory {}'.format(mems[0].id))
 
-            mems[0].vid = 0xBC
-            mems[0].pid = 0xFF
+            # Setting VID:PID to 00:00 will make the Crazyflie match driver to the board name 
+            mems[0].vid = 0x00
+            mems[0].pid = 0x00
 
             board_name_id = OWElement.element_mapping[1]
             board_rev_id = OWElement.element_mapping[2]
 
-            mems[0].elements[board_name_id] = 'Test board'
+            mems[0].elements[board_name_id] = 'Hello deck'
             mems[0].elements[board_rev_id] = 'A'
 
             mems[0].write_data(self._data_written)

--- a/examples/memory/write-ow.py
+++ b/examples/memory/write-ow.py
@@ -73,7 +73,7 @@ class WriteOwExample:
             print('Writing test configuration to'
                   ' memory {}'.format(mems[0].id))
 
-            # Setting VID:PID to 00:00 will make the Crazyflie match driver to the board name 
+            # Setting VID:PID to 00:00 will make the Crazyflie match driver to the board name
             mems[0].vid = 0x00
             mems[0].pid = 0x00
 

--- a/examples/memory/write-ow.py
+++ b/examples/memory/write-ow.py
@@ -24,10 +24,6 @@
 """
 This example connects to the first Crazyflie that it finds and writes to the
 one wire memory.
-
-Note: this example will not work with the BLE version of the nRF51 firmware
-(flashed on production units).
-See https://github.com/bitcraze/crazyflie-clients-python/issues/166
 """
 import logging
 import sys
@@ -134,10 +130,6 @@ class WriteOwExample:
 
 
 if __name__ == '__main__':
-    print('This example will not work with the BLE version of the nRF51'
-          ' firmware (flashed on production units). See https://github.com'
-          '/bitcraze/crazyflie-clients-python/issues/166')
-
     # Initialize the low-level drivers
     cflib.crtp.init_drivers()
 


### PR DESCRIPTION
This PR solves:
 - Removes an uncecessary warning from the OW examples
 - Change write-ow to write a more harmless config
 - Fix erase-ow