### PR TITLE
Fix USB connection to CF

### DIFF
--- a/cflib/crtp/usbdriver.py
+++ b/cflib/crtp/usbdriver.py
@@ -70,16 +70,15 @@ class UsbDriver(CRTPDriver):
         """
 
         # check if the URI is a radio URI
-        if not re.search('^usb://', uri):
+        uri_data = re.search('^usb://([0-9]+)$',
+                             uri)
+        if not uri_data:
             raise WrongUriType('Not a radio URI')
 
         # Open the USB dongle
         if not re.search('^usb://([0-9]+)$',
                          uri):
             raise WrongUriType('Wrong radio URI format!')
-
-        uri_data = re.search('^usb://([0-9]+)$',
-                             uri)
 
         self.uri = uri
 

--- a/cflib/drivers/cfusb.py
+++ b/cflib/drivers/cfusb.py
@@ -27,6 +27,7 @@ USB driver for the Crazyflie.
 """
 import logging
 import os
+import platform
 
 import libusb_package
 import usb
@@ -90,6 +91,9 @@ class CfUsb:
                 self.dev = None
 
         if self.dev:
+            if platform.system() == 'Linux':
+                self.dev.reset()
+            
             self.dev.set_configuration(1)
             self.handle = self.dev
             self.version = float(
@@ -118,7 +122,7 @@ class CfUsb:
             return [('usb://0', '')]
         return []
 
-    def set_crtp_to_usb(self, crtp_to_usb):
+    def set_crtp_to_usb(self, crtp_to_usb: bool):
         if crtp_to_usb:
             _send_vendor_setup(self.handle, 0x01, 0x01, 1, ())
         else:

--- a/cflib/drivers/cfusb.py
+++ b/cflib/drivers/cfusb.py
@@ -93,7 +93,7 @@ class CfUsb:
         if self.dev:
             if platform.system() == 'Linux':
                 self.dev.reset()
-            
+
             self.dev.set_configuration(1)
             self.handle = self.dev
             self.version = float(


### PR DESCRIPTION
Adding a USB reset seems to fix the USB connection to the Crazyflie when
trying to connect multiple times.

This has been tested on one Linux machine. This needs to be tested on
other machines and OS. Follow the procedure explained on the ticket #264 to test.

Fixes #264