### PR TITLE
Add suport for flashing both ESP and GAP8 on the AI-deck

### DIFF
--- a/cflib/bootloader/__init__.py
+++ b/cflib/bootloader/__init__.py
@@ -384,6 +384,14 @@ class Bootloader:
 
         return identifier
 
+
+    def console_callback(self, text: str):
+        '''A callback to run when we get console text from Crazyflie'''
+        # We do not add newlines to the text received, we get them from the
+        # Crazyflie at appropriate places.
+        print(text, end='')
+
+
     def _flash_deck(self, artifacts: List[FlashArtifact], targets: List[Target]):
         flash_all_targets = len(targets) == 0
 
@@ -391,6 +399,9 @@ class Bootloader:
             self.progress_cb('Detecting deck to be updated', 0)
 
         with SyncCrazyflie(self.clink, cf=Crazyflie()) as scf:
+            # Uncomment to enable console logs from the CF. Useful when debuging deck flashing.
+            # scf.cf.console.receivedChar.add_callback(self.console_callback)
+
             deck_mems = scf.cf.mem.get_mems(MemoryElement.TYPE_DECK_MEMORY)
             deck_mems_count = len(deck_mems)
             if deck_mems_count == 0:

--- a/cflib/bootloader/__init__.py
+++ b/cflib/bootloader/__init__.py
@@ -448,7 +448,7 @@ class Bootloader:
                 timeout_time = time.time() + 5
                 while not deck.is_started:
                     if time.time() > timeout_time:
-                        raise RuntimeError(f"Deck {deck.name} did not start")
+                        raise RuntimeError(f'Deck {deck.name} did not start')
                     print('Deck not yet started ...')
                     time.sleep(0.5)
                     deck = mgr.query_decks()[deck_index]
@@ -475,7 +475,7 @@ class Bootloader:
                 timeout_time = time.time() + 5
                 while not deck.is_bootloader_active:
                     if time.time() > timeout_time:
-                        raise RuntimeError(f"Deck {deck.name} did not enter bootloader mode")
+                        raise RuntimeError(f'Deck {deck.name} did not enter bootloader mode')
                     print(f'Error: Deck {deck.name} bootloader not active yet...')
                     time.sleep(0.5)
                     deck = mgr.query_decks()[deck_index]

--- a/cflib/bootloader/__init__.py
+++ b/cflib/bootloader/__init__.py
@@ -171,7 +171,8 @@ class Bootloader:
                 current_index = 0
                 while current_index != -1:
                     current_index = self._flash_deck_incrementally(deck_artifacts, deck_targets, current_index)
-                    self.progress_cb('Deck updated! Restarting...', int(100))
+                    if self.progress_cb:
+                        self.progress_cb('Deck updated! Restarting...', int(100))
                     if current_index != -1:
                         PowerSwitch(self.clink).reboot_to_fw()
                         time.sleep(3)

--- a/cflib/crazyflie/mem/deck_memory.py
+++ b/cflib/crazyflie/mem/deck_memory.py
@@ -53,7 +53,7 @@ class DeckMemory:
     ADR_FW_NEW_FLASH = 0
     ADR_COMMAND_BIT_FIELD = 4
 
-    def __init__(self, deck_memory_manager: "DeckMemoryManager", _command_base_address):
+    def __init__(self, deck_memory_manager: 'DeckMemoryManager', _command_base_address):
         self._deck_memory_manager = deck_memory_manager
         self.required_hash = None
         self.required_length = None

--- a/cflib/crazyflie/mem/deck_memory.py
+++ b/cflib/crazyflie/mem/deck_memory.py
@@ -286,13 +286,13 @@ class DeckMemoryManager(MemoryElement):
 
         return result
 
-    def _write(self, base_address, address, data, read_complete_cb, read_failed_cb, progress_cb):
+    def _write(self, base_address, address, data, complete_cb, failed_cb, progress_cb):
         """Called from deck memory to write data"""
         if self._write_complete_cb is not None:
             raise Exception('Write operation ongoing')
 
-        self._write_complete_cb = read_complete_cb
-        self._write_failed_cb = read_failed_cb
+        self._write_complete_cb = complete_cb
+        self._write_failed_cb = failed_cb
 
         mapped_address = address + base_address
         self.mem_handler.write(self, mapped_address, data, flush_queue=True, progress_cb=progress_cb)

--- a/cflib/crazyflie/mem/deck_memory.py
+++ b/cflib/crazyflie/mem/deck_memory.py
@@ -42,16 +42,27 @@ class DeckMemory:
     MASK_UPGRADE_REQUIRED = 32
     MASK_BOOTLOADER_ACTIVE = 64
 
+    MASK_SUPPORTS_RESET_TO_FW = 1
+    MASK_SUPPORTS_RESET_TO_BOOTLOADER = 2
+
+    FLAG_COMMAND_RESET_TO_FW = 1
+    FLAG_COMMAND_RESET_TO_BOOTLOADER = 2
+
     MEMORY_MAX_SIZE = 0x10000000
 
-    def __init__(self, deck_memory_manager):
+    ADR_FW_NEW_FLASH = 0
+    ADR_COMMAND_BIT_FIELD = 4
+
+    def __init__(self, deck_memory_manager: "DeckMemoryManager", _command_base_address):
         self._deck_memory_manager = deck_memory_manager
         self.required_hash = None
         self.required_length = None
         self.name = None
 
         self._base_address = None
-        self._bit_field = 0
+        self._command_base_address = _command_base_address
+        self._bit_field1 = 0
+        self._bit_field2 = 0
 
     def contains(self, address):
         max = self._base_address + self.MEMORY_MAX_SIZE
@@ -95,41 +106,72 @@ class DeckMemory:
 
     @property
     def is_valid(self):
-        return (self._bit_field & self.MASK_IS_VALID) != 0
+        return (self._bit_field1 & self.MASK_IS_VALID) != 0
 
     @property
     def is_started(self):
-        return (self._bit_field & self.MASK_IS_STARTED) != 0
+        return (self._bit_field1 & self.MASK_IS_STARTED) != 0
 
     @property
     def supports_read(self):
-        return (self._bit_field & self.MASK_SUPPORTS_READ) != 0
+        return (self._bit_field1 & self.MASK_SUPPORTS_READ) != 0
 
     @property
     def supports_write(self):
-        return (self._bit_field & self.MASK_SUPPORTS_WRITE) != 0
+        return (self._bit_field1 & self.MASK_SUPPORTS_WRITE) != 0
 
     @property
     def supports_fw_upgrade(self):
-        return (self._bit_field & self.MASK_SUPPORTS_UPGRADE) != 0
+        return (self._bit_field1 & self.MASK_SUPPORTS_UPGRADE) != 0
 
     @property
     def is_fw_upgrade_required(self):
-        return (self._bit_field & self.MASK_UPGRADE_REQUIRED) != 0
+        return (self._bit_field1 & self.MASK_UPGRADE_REQUIRED) != 0
 
     @property
     def is_bootloader_active(self):
-        return (self._bit_field & self.MASK_BOOTLOADER_ACTIVE) != 0
+        return (self._bit_field1 & self.MASK_BOOTLOADER_ACTIVE) != 0
+
+    @property
+    def supports_reset_to_fw(self):
+        return (self._bit_field2 & self.MASK_SUPPORTS_RESET_TO_FW) != 0
+
+    @property
+    def supports_reset_to_bootloader(self):
+        return (self._bit_field2 & self.MASK_SUPPORTS_RESET_TO_BOOTLOADER) != 0
+
+    def reset_to_fw(self):
+        data = struct.pack('<B', self.FLAG_COMMAND_RESET_TO_FW)
+        self._write_command_data(self.ADR_COMMAND_BIT_FIELD, data)
+
+    def reset_to_bootloader(self):
+        data = struct.pack('<B', self.FLAG_COMMAND_RESET_TO_BOOTLOADER)
+        self._write_command_data(self.ADR_COMMAND_BIT_FIELD, data)
+
+    def set_fw_new_flash_size(self, size):
+        data = struct.pack('<L', size)
+        self._write_command_data(self.ADR_FW_NEW_FLASH, data)
 
     def _parse(self, data):
-        self._bit_field = struct.unpack('<B', data[0:1])[0]
+        self._bit_field1, self._bit_field2 = struct.unpack('<BB', data[0:2])
         if self.is_valid:
             try:
-                self.required_hash, self.required_length, self._base_address, _name = struct.unpack('<LLL19s', data[1:])
+                self.required_hash, self.required_length, self._base_address, _name = struct.unpack('<LLL18s', data[2:])
                 self.name = _name.split(b'\x00')[0].decode()
             except Exception as e:
                 logger.warning(f'Error while decoding deck mem ({e}), skipping!')
-                self._bit_field = 0
+                self._bit_field1 = 0
+                self._bit_field2 = 0
+
+    def _write_command_data(self, address, data):
+        if not self.is_started:
+            raise Exception('Deck not ready')
+
+        syncer = Syncer()
+        self._deck_memory_manager._write(self._command_base_address, address, data, syncer.success_cb,
+                                         syncer.failure_cb, None)
+        syncer.wait()
+        return syncer.is_success
 
 
 class DeckMemoryManager(MemoryElement):
@@ -144,7 +186,9 @@ class DeckMemoryManager(MemoryElement):
     SIZE_OF_VERSION = 1
     SIZE_OF_INFO_SECTION = SIZE_OF_VERSION + MAX_NR_OF_DECKS * SIZE_OF_DECK_MEM_INFO
     INFO_SECTION_ADDRESS = 0
-    SUPPORTED_VERSION = 2
+    COMMAND_SECTION_ADDRESS = 0x1000
+    SIZE_OF_COMMAND_SECTION = 0x20
+    SUPPORTED_VERSION = 3
 
     def __init__(self, id, type, size, mem_handler):
         """Initialize deck memory manager"""
@@ -159,7 +203,6 @@ class DeckMemoryManager(MemoryElement):
 
         self._write_complete_cb = None
         self._write_failed_cb = None
-        self._write_base_address = 0
 
     def query_decks(self, query_complete_cb):
         if self._query_complete_cb is not None:
@@ -223,7 +266,7 @@ class DeckMemoryManager(MemoryElement):
             logger.error(f'Version {version} not supported')
         else:
             for i in range(self.MAX_NR_OF_DECKS):
-                deck_memory = DeckMemory(self)
+                deck_memory = DeckMemory(self, self.COMMAND_SECTION_ADDRESS + i * self.SIZE_OF_COMMAND_SECTION)
                 start = self.SIZE_OF_VERSION + self.SIZE_OF_DECK_MEM_INFO * i
                 end = start + self.SIZE_OF_DECK_MEM_INFO
                 deck_memory._parse(data[start:end])
@@ -237,11 +280,10 @@ class DeckMemoryManager(MemoryElement):
         if self._write_complete_cb is not None:
             raise Exception('Write operation ongoing')
 
-        self._write_base_address = base_address
         self._write_complete_cb = read_complete_cb
         self._write_failed_cb = read_failed_cb
 
-        mapped_address = address + self._write_base_address
+        mapped_address = address + base_address
         self.mem_handler.write(self, mapped_address, data, flush_queue=True, progress_cb=progress_cb)
 
     def _write_done(self, mem, addr):

--- a/cflib/crazyflie/mem/deck_memory.py
+++ b/cflib/crazyflie/mem/deck_memory.py
@@ -263,7 +263,7 @@ class DeckMemoryManager(MemoryElement):
 
         version = struct.unpack('<B', data[0:1])[0]
         if version != self.SUPPORTED_VERSION:
-            logger.error(f'Version {version} not supported')
+            logger.error(f'Deck memory version {version} not supported')
         else:
             for i in range(self.MAX_NR_OF_DECKS):
                 deck_memory = DeckMemory(self, self.COMMAND_SECTION_ADDRESS + i * self.SIZE_OF_COMMAND_SECTION)

--- a/cflib/crazyflie/mem/deck_memory.py
+++ b/cflib/crazyflie/mem/deck_memory.py
@@ -195,6 +195,7 @@ class DeckMemoryManager(MemoryElement):
         super(DeckMemoryManager, self).__init__(id=id, type=type, size=size, mem_handler=mem_handler)
 
         self._query_complete_cb = None
+        self._query_failed_cb = None
         self.deck_memories = {}
 
         self._read_complete_cb = None
@@ -203,13 +204,16 @@ class DeckMemoryManager(MemoryElement):
 
         self._write_complete_cb = None
         self._write_failed_cb = None
+        self._error = None
 
-    def query_decks(self, query_complete_cb):
+    def query_decks(self, query_complete_cb, query_failed_cb=None):
         if self._query_complete_cb is not None:
             raise Exception('Query ongoing')
 
+        self._error = None
         self.deck_memories = {}
         self._query_complete_cb = query_complete_cb
+        self._query_failed_cb = query_failed_cb
         self.mem_handler.read(self, self.INFO_SECTION_ADDRESS, self.SIZE_OF_INFO_SECTION)
 
     def _read(self, base_address, address, length, read_complete_cb, read_failed_cb):
@@ -228,10 +232,16 @@ class DeckMemoryManager(MemoryElement):
         """Callback when new memory data has been fetched"""
         if mem.id == self.id:
             if addr == self.INFO_SECTION_ADDRESS:
-                self.deck_memories = self._parse_info_section(data)
-                tmp_cb = self._query_complete_cb
-                self._clear_query_cb()
-                tmp_cb(self.deck_memories)
+                try:
+                    self.deck_memories = self._parse_info_section(data)
+                    tmp_cb = self._query_complete_cb
+                    self._clear_query_cb()
+                    tmp_cb(self.deck_memories)
+                except RuntimeError as e:
+                    tmp_cb = self._query_failed_cb
+                    self._clear_query_cb()
+                    if tmp_cb:
+                        tmp_cb(str(e))
             else:
                 tmp_cb = self._read_complete_cb
                 self._clear_read_cb()
@@ -253,6 +263,7 @@ class DeckMemoryManager(MemoryElement):
 
     def _clear_query_cb(self):
         self._query_complete_cb = None
+        self._query_failed_cb = None
 
     def _clear_read_cb(self):
         self._read_complete_cb = None
@@ -263,7 +274,7 @@ class DeckMemoryManager(MemoryElement):
 
         version = struct.unpack('<B', data[0:1])[0]
         if version != self.SUPPORTED_VERSION:
-            logger.error(f'Deck memory version {version} not supported')
+            raise RuntimeError(f'Deck memory version {version} not supported')
         else:
             for i in range(self.MAX_NR_OF_DECKS):
                 deck_memory = DeckMemory(self, self.COMMAND_SECTION_ADDRESS + i * self.SIZE_OF_COMMAND_SECTION)
@@ -321,6 +332,9 @@ class SyncDeckMemoryManager:
 
     def query_decks(self):
         syncer = Syncer()
-        self._deck_memory_manager.query_decks(syncer.success_cb)
+        self._deck_memory_manager.query_decks(syncer.success_cb, syncer.failure_cb)
         syncer.wait()
-        return syncer.success_args[0]
+        if syncer.is_success:
+            return syncer.success_args[0]
+
+        raise RuntimeError(syncer.failure_args[0])

--- a/cflib/utils/callbacks.py
+++ b/cflib/utils/callbacks.py
@@ -55,7 +55,7 @@ class Caller():
 
 
 class Syncer:
-    """A class to create syncronous behaviour for methods using callbacks"""
+    """A class to create synchronous behavior for methods using callbacks"""
 
     def __init__(self):
         self._event = Event()


### PR DESCRIPTION
Support updated deck memory mapping and more complex flashing

* Updated deck memory mapping. New protocol version, requires bitcraze/crazyflie-firmware#1003
* Support for flashing multiple decks from one zip, with reboot between each deck