### PR TITLE
Update opencv-python-headless

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'libusb-package~=1.0',
         'scipy~=1.7',
         'numpy>=1.20,<1.25',
-        'opencv-python-headless~=4.5.1',
+        'opencv-python-headless~=4.5.5',
     ],
 
     # $ pip install -e .[dev]


### PR DESCRIPTION
with opencv-python-headless version 4.5.1.48, I got the following error if I wanted to estimate the basestation geometry, namely that cv2 was missing the rodriquez function. With the latest and greatest of 4.5.5, this was fixed on opencv side again.