### PR TITLE
Altered cfusb driver so it works with a composite usb device

### DIFF
--- a/cflib/drivers/cfusb.py
+++ b/cflib/drivers/cfusb.py
@@ -89,16 +89,22 @@ class CfUsb:
                 self.dev = devices[devid]
             except Exception:
                 self.dev = None
-
-        if self.dev:
-            if platform.system() == 'Linux':
-                self.dev.reset()
-
-            self.dev.set_configuration(1)
-            self.handle = self.dev
-            self.version = float(
-                '{0:x}.{1:x}'.format(self.dev.bcdDevice >> 8,
-                                     self.dev.bcdDevice & 0x0FF))
+    
+        try: # configuration might already be confgiured by composite VCP, try claim interface
+            usb.util.claim_interface(self.dev, 0)
+        except Exception:
+            try: 
+                self.dev.set_configuration() #it was not, then set configuration
+            except Exception:
+                if self.dev:
+                    if platform.system() == 'Linux':
+                        self.dev.reset()
+                        self.dev.set_configuration()
+            
+        self.handle = self.dev
+        self.version = float(
+            '{0:x}.{1:x}'.format(self.dev.bcdDevice >> 8,
+                                 self.dev.bcdDevice & 0x0FF))
 
     def get_serial(self):
         # The signature for get_string has changed between versions to 1.0.0b1,

--- a/cflib/drivers/cfusb.py
+++ b/cflib/drivers/cfusb.py
@@ -89,18 +89,18 @@ class CfUsb:
                 self.dev = devices[devid]
             except Exception:
                 self.dev = None
-    
-        try: # configuration might already be confgiured by composite VCP, try claim interface
+
+        try:  # configuration might already be confgiured by composite VCP, try claim interface
             usb.util.claim_interface(self.dev, 0)
         except Exception:
-            try: 
-                self.dev.set_configuration() #it was not, then set configuration
+            try:
+                self.dev.set_configuration()  # it was not, then set configuration
             except Exception:
                 if self.dev:
                     if platform.system() == 'Linux':
                         self.dev.reset()
                         self.dev.set_configuration()
-            
+
         self.handle = self.dev
         self.version = float(
             '{0:x}.{1:x}'.format(self.dev.bcdDevice >> 8,


### PR DESCRIPTION
For Bolt and CF2.1-BL a virtual com port is needed so BLheli ESCs can be configured easily. This change adds support so it works with a composite usb device.

I've changed the reset that was added to fix #312 because this broke the composite usb enumeration. I could not replicate the problem described in #312 after my change.