### PR TITLE
Fixed float param bug

### DIFF
--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -338,10 +338,10 @@ class Param():
             else:
                 pk.data = struct.pack('<B', varid)
 
-            try:
-                value_nr = int(value)
-            except ValueError:
+            if element.pytype == '<f' or element.pytype == '<d':
                 value_nr = float(value)
+            else:
+                value_nr = int(value)
 
             pk.data += struct.pack(element.pytype, value_nr)
             self.param_updater.request_param_setvalue(pk)


### PR DESCRIPTION
When a parameter that is a float or double is set, the value is converted to an int and the decimals are lost.

This PR fixes the problem by using the type of the parameter to decide if it syould be cast to int of float before packing it.

It would have been nicer to add this knowledge to the ParamTocElement class but the param cache stores the full python class and when reading an old cache we get instances of the old ParamTocElement class. Adding new functionality to the ParamTocElement class means we would have to clear the cache somehow.