### PR TITLE
Add start address to trajectory memory write

### DIFF
--- a/examples/autonomy/autonomous_sequence_high_level.py
+++ b/examples/autonomy/autonomous_sequence_high_level.py
@@ -65,27 +65,26 @@ figure8 = [
 class Uploader:
     def __init__(self):
         self._is_done = False
-        self._sucess = True
+        self._success = True
 
     def upload(self, trajectory_mem):
         print('Uploading data')
-        trajectory_mem.write_data(self._upload_done,
-                                  write_failed_cb=self._upload_failed)
+        trajectory_mem.write_data(self._upload_done, write_failed_cb=self._upload_failed)
 
         while not self._is_done:
             time.sleep(0.2)
 
-        return self._sucess
+        return self._success
 
     def _upload_done(self, mem, addr):
         print('Data uploaded')
         self._is_done = True
-        self._sucess = True
+        self._success = True
 
     def _upload_failed(self, mem, addr):
         print('Data upload failed')
         self._is_done = True
-        self._sucess = False
+        self._success = False
 
 
 def wait_for_position_estimator(scf):
@@ -147,6 +146,7 @@ def activate_mellinger_controller(cf):
 
 def upload_trajectory(cf, trajectory_id, trajectory):
     trajectory_mem = cf.mem.get_mems(MemoryElement.TYPE_TRAJ)[0]
+    trajectory_mem.trajectory = []
 
     total_duration = 0
     for row in trajectory:

--- a/examples/autonomy/autonomous_sequence_high_level_compressed.py
+++ b/examples/autonomy/autonomous_sequence_high_level_compressed.py
@@ -61,27 +61,26 @@ trajectory = [
 class Uploader:
     def __init__(self):
         self._is_done = False
-        self._sucess = True
+        self._success = True
 
     def upload(self, trajectory_mem):
         print('Uploading data')
-        trajectory_mem.write_data(self._upload_done,
-                                  write_failed_cb=self._upload_failed)
+        trajectory_mem.write_data(self._upload_done, write_failed_cb=self._upload_failed)
 
         while not self._is_done:
             time.sleep(0.2)
 
-        return self._sucess
+        return self._success
 
     def _upload_done(self, mem, addr):
         print('Data uploaded')
         self._is_done = True
-        self._sucess = True
+        self._success = True
 
     def _upload_failed(self, mem, addr):
         print('Data upload failed')
         self._is_done = True
-        self._sucess = False
+        self._success = False
 
 
 def wait_for_position_estimator(scf):


### PR DESCRIPTION
Add the possibility to set the start address of an upload to the trajectory memory. This will make it easier to use more than one trajectory.
Also changed the `write_data()` method to return the size of the trajectory (in bytes), to make it easier to manage the memory.