### PR TITLE
Rework parameters during connection

### DIFF
--- a/cflib/crazyflie/__init__.py
+++ b/cflib/crazyflie/__init__.py
@@ -85,8 +85,7 @@ class Crazyflie():
         self.link_established = Caller()
         # Called when the user requests a connection
         self.connection_requested = Caller()
-        # Called when the link is established and the TOCs (that are not
-        # cached) have been downloaded
+        # Called when the link is established and the TOCs (that are not cached) have been downloaded
         self.connected = Caller()
         # Called when the the link is established and all data, including parameters have been downloaded
         self.fully_connected = Caller()
@@ -143,14 +142,11 @@ class Crazyflie():
         self.link_established.add_callback(
             lambda uri: logger.info('Callback->Connected to [%s]', uri))
         self.connection_lost.add_callback(
-            lambda uri, errmsg: logger.info(
-                'Callback->Connection lost to [%s]: %s', uri, errmsg))
+            lambda uri, errmsg: logger.info('Callback->Connection lost to [%s]: %s', uri, errmsg))
         self.connection_failed.add_callback(
-            lambda uri, errmsg: logger.info(
-                'Callback->Connected failed to [%s]: %s', uri, errmsg))
+            lambda uri, errmsg: logger.info('Callback->Connected failed to [%s]: %s', uri, errmsg))
         self.connection_requested.add_callback(
-            lambda uri: logger.info(
-                'Callback->Connection initialized[%s]', uri))
+            lambda uri: logger.info('Callback->Connection initialized[%s]', uri))
         self.connected.add_callback(
             lambda uri: logger.info('Callback->Connection setup finished [%s]', uri))
         self.fully_connected.add_callback(

--- a/cflib/crazyflie/__init__.py
+++ b/cflib/crazyflie/__init__.py
@@ -34,6 +34,7 @@ import datetime
 import logging
 import time
 from collections import namedtuple
+from threading import current_thread
 from threading import Lock
 from threading import Thread
 from threading import Timer
@@ -353,6 +354,9 @@ class Crazyflie():
             self.link.send_packet(pk)
             self.packet_sent.call(pk)
         self._send_lock.release()
+
+    def is_called_by_incoming_handler_thread(self):
+        return current_thread() == self.incoming
 
 
 _CallbackContainer = namedtuple('CallbackConstainer',

--- a/cflib/crazyflie/__init__.py
+++ b/cflib/crazyflie/__init__.py
@@ -88,6 +88,9 @@ class Crazyflie():
         # Called when the link is established and the TOCs (that are not
         # cached) have been downloaded
         self.connected = Caller()
+        # Called when the the link is established and all data, including parameters have been downloaded
+        self.fully_connected = Caller()
+
         # Called if establishing of the link fails (i.e times out)
         self.connection_failed = Caller()
         # Called for every packet received
@@ -131,6 +134,8 @@ class Crazyflie():
 
         self.connected_ts = None
 
+        self.param.all_updated.add_callback(self._all_parameters_updated)
+
         # Connect callbacks to logger
         self.disconnected.add_callback(
             lambda uri: logger.info('Callback->Disconnected from [%s]', uri))
@@ -147,8 +152,9 @@ class Crazyflie():
             lambda uri: logger.info(
                 'Callback->Connection initialized[%s]', uri))
         self.connected.add_callback(
-            lambda uri: logger.info(
-                'Callback->Connection setup finished [%s]', uri))
+            lambda uri: logger.info('Callback->Connection setup finished [%s]', uri))
+        self.fully_connected.add_callback(
+            lambda uri: logger.info('Callback->Connection completed [%s]', uri))
 
     def _disconnected(self, link_uri):
         """ Callback when disconnected."""
@@ -180,6 +186,11 @@ class Crazyflie():
         """Called when the log TOC has been fully updated"""
         logger.info('Log TOC finished updating')
         self.mem.refresh(self._mems_updated_cb)
+
+    def _all_parameters_updated(self):
+        """Called when all parameters have been updated"""
+        logger.info('All parameters updated')
+        self.fully_connected.call(self.link_uri)
 
     def _link_error_cb(self, errmsg):
         """Called from the link driver when there's an error"""

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -537,8 +537,7 @@ class _ExtendedTypeFetcher(Thread):
             pk = CRTPPacket()
             pk.set_header(CRTPPort.PARAM, MISC_CHANNEL)
 
-            pk.data = struct.pack('<BH',
-                                  MISC_GET_EXTENDED_TYPE, element.ident)
+            pk.data = struct.pack('<BH', MISC_GET_EXTENDED_TYPE, element.ident)
             self.request_queue.put(pk)
 
     def _close(self):

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -203,13 +203,6 @@ class Param():
                 self.values[element.group] = {}
             self.values[element.group][element.name] = s
 
-            # Once all the parameters are updated call the
-            # callback for "everything updated"
-            if self._check_if_all_updated() and not self.is_updated:
-                self.is_updated = True
-                self._initialized.set()
-                self.all_updated.call()
-
             logger.debug('Updated parameter [%s]' % complete_name)
             if complete_name in self.param_update_callbacks:
                 self.param_update_callbacks[complete_name].call(
@@ -218,6 +211,13 @@ class Param():
                 self.group_update_callbacks[element.group].call(
                     complete_name, s)
             self.all_update_callback.call(complete_name, s)
+
+            # Once all the parameters are updated call the
+            # callback for "everything updated"
+            if self._check_if_all_updated() and not self.is_updated:
+                self.is_updated = True
+                self._initialized.set()
+                self.all_updated.call()
         else:
             logger.debug('Variable id [%d] not found in TOC', var_id)
 

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -152,11 +152,11 @@ class Param():
         self.all_update_callback = Caller()
         self.param_updater = None
 
-        self.param_updater = _ParamUpdater(
-            self.cf, self._useV2, self._param_updated)
+        self.param_updater = _ParamUpdater(self.cf, self._useV2, self._param_updated)
         self.param_updater.start()
 
         self.cf.disconnected.add_callback(self._disconnected)
+        self.cf.connection_requested.add_callback(self._connection_requested)
 
         self.all_updated = Caller()
         self.is_updated = False
@@ -277,11 +277,19 @@ class Param():
                                  refresh_done, toc_cache)
         toc_fetcher.start()
 
+    def _connection_requested(self, uri):
+        # Reset the internal state on connect to make sure we have a clean state
+        self.is_updated = False
+        self.toc = Toc()
+        self.values = {}
+        self._initialized.clear()
+
     def _disconnected(self, uri):
         """Disconnected callback from Crazyflie API"""
         self.param_updater.close()
-        self.is_updated = False
-        self._initialized.clear()
+
+        # Do not clear self.is_updated here as we might get spurious parameter updates later
+
         # Clear all values from the previous Crazyflie
         self.toc = Toc()
         self.values = {}

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -316,8 +316,11 @@ class Param():
         """
         Set the value for the supplied parameter.
         """
-        if not self._initialized.wait(timeout=60):
-            raise Exception('Connection timed out')
+        if not self._initialized.isSet():
+            if self.cf.is_called_by_incoming_handler_thread():
+                raise Exception('Can not set parameter from callback until fully connected.')
+            if not self._initialized.wait(timeout=60):
+                raise Exception('Connection timed out')
 
         element = self.toc.get_element_by_complete_name(complete_name)
 
@@ -351,8 +354,11 @@ class Param():
         Read a value for the supplied parameter. This can block for a period
         of time if the parameter values have not been fetched yet.
         """
-        if not self._initialized.wait(timeout=60):
-            raise Exception('Connection timed out')
+        if not self._initialized.isSet():
+            if self.cf.is_called_by_incoming_handler_thread():
+                raise Exception('Can not get parameter from callback until fully connected.')
+            if not self._initialized.wait(timeout=60):
+                raise Exception('Connection timed out')
 
         [group, name] = complete_name.split('.')
         return self.values[group][name]

--- a/cflib/crazyflie/syncCrazyflie.py
+++ b/cflib/crazyflie/syncCrazyflie.py
@@ -6,7 +6,7 @@
 #  +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
 #   ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
 #
-#  Copyright (C) 2016 Bitcraze AB
+#  Copyright (C) 2016-2022 Bitcraze AB
 #
 #  Crazyflie Nano Quadcopter Client
 #
@@ -159,14 +159,14 @@ class SyncCrazyflie:
         if self._disconnect_event:
             self._disconnect_event.set()
 
-    def _all_params_updated(self):
+    def _all_params_updated(self, link_uri):
         self._params_updated_event.set()
 
     def _add_callbacks(self):
         self.cf.connected.add_callback(self._connected)
         self.cf.connection_failed.add_callback(self._connection_failed)
         self.cf.disconnected.add_callback(self._disconnected)
-        self.cf.param.all_updated.add_callback(self._all_params_updated)
+        self.cf.fully_connected.add_callback(self._all_params_updated)
 
     def _remove_callbacks(self):
         def remove_callback(container, callback):
@@ -178,4 +178,4 @@ class SyncCrazyflie:
         remove_callback(self.cf.connected, self._connected)
         remove_callback(self.cf.connection_failed, self._connection_failed)
         remove_callback(self.cf.disconnected, self._disconnected)
-        remove_callback(self.cf.param.all_updated, self._all_params_updated)
+        remove_callback(self.cf.fully_connected, self._all_params_updated)

--- a/docs/user-guides/python_api.md
+++ b/docs/user-guides/python_api.md
@@ -36,7 +36,7 @@ ideas for more like *udp*, *serial*, *usb*, etc\...Here are some
 examples:
 
 -   _radio://0/10/250K_ : Radio interface, USB dongle number 0, radio channel 10 and radio
-    speed 250 Kbit/s: radio://0/10/250K 
+    speed 250 Kbit/s: radio://0/10/250K
 -   _debug://0/1_ : Debug interface, id 0, channel 1
 
 ### Variables and logging
@@ -159,6 +159,8 @@ the following callbacks when events occur:
     # Called when the link is established and the TOCs (that are not cached)
     # have been downloaded
     connected = Caller()
+    # Called when the the link is established and all data, including parameters have been downloaded
+    fully_connected = Caller()
     # Called if establishing of the link fails (i.e times out)
     connection_failed = Caller()
     # Called for every packet received
@@ -258,7 +260,7 @@ functionality should be used when:
 If this is not the case then the logging framework should be used
 instead.
 
-To set a parameter you have to the connected to the Crazyflie. A
+To set a parameter you must have the connected to the Crazyflie. A
 parameter is set using:
 
 ``` python
@@ -296,6 +298,21 @@ Here\'s an example of how to use the calls.
     def param_updated_callback(name, value):
         print "%s has value %d" % (name, value)
 ```
+
+It is also possible to get the current value of a parameter (when connected) without using a callback
+``` python
+    value = get_value(complete_name)
+```
+
+Note 1: If you call `set_value()` and then directly call `get_value()` for a parameter, you might not read back the new
+value, but get the old one instead. The process is asynchronous and `get_value()` will not return the new value until
+the parameter value has propagated to the Crazyflie and back. Use the callback method if you need to be certain
+that you get the correct value after an update.
+
+Note 2: `get_value()` and `set_value()` can not be called from callbacks until the Crazyflie is fully connected.
+Most notably they can not be called from the `connected` callback as the parameter values have not been
+downloaded yet. Use the `fully_connected` callback to make sure the system is ready for parameter use. It is OK to
+call `get_value()` and `set_value()` from the `fully_connected` callback.
 
 ## Logging
 

--- a/examples/parameters/basicparam.py
+++ b/examples/parameters/basicparam.py
@@ -34,7 +34,7 @@ import cflib.crtp
 from cflib.crazyflie import Crazyflie
 from cflib.utils import uri_helper
 
-address = uri_helper.address_from_env(default=0xE7E7E7E7E7)
+address = uri_helper.uri_from_env(default='radio://0/80/2M/E7E7E7E7E7')
 
 # Only output errors from the logging framework
 logging.basicConfig(level=logging.ERROR)
@@ -53,6 +53,7 @@ class ParamExample:
 
         # Connect some callbacks from the Crazyflie API
         self._cf.connected.add_callback(self._connected)
+        self._cf.fully_connected.add_callback(self._fully_connected)
         self._cf.disconnected.add_callback(self._disconnected)
         self._cf.connection_failed.add_callback(self._connection_failed)
         self._cf.connection_lost.add_callback(self._connection_lost)
@@ -72,7 +73,7 @@ class ParamExample:
 
     def _connected(self, link_uri):
         """ This callback is called form the Crazyflie API when a Crazyflie
-        has been connected and the TOCs have been downloaded."""
+        has been connected and the TOCs have been downloaded. Parameter values are not downloaded yet."""
         print('Connected to %s' % link_uri)
 
         # Print the param TOC
@@ -84,14 +85,28 @@ class ParamExample:
                 self._param_check_list.append('{0}.{1}'.format(group, param))
             self._param_groups.append('{}'.format(group))
             # For every group, register the callback
-            self._cf.param.add_update_callback(group=group, name=None,
-                                               cb=self._param_callback)
+            self._cf.param.add_update_callback(group=group, name=None, cb=self._param_callback)
 
         # You can also register a callback for a specific group.name combo
         self._cf.param.add_update_callback(group='cpu', name='flash',
                                            cb=self._cpu_flash_callback)
 
         print('')
+
+    def _fully_connected(self, link_uri):
+        """This callback is called when the Crazyflie has been connected and all parameters have been
+        downloaded. It is now OK to set and get parameters."""
+        print(f'Parameters downloaded to {link_uri}')
+
+        # We can get a parameter value directly without using a callback
+        value = self._cf.param.get_value('pid_attitude.pitch_kd')
+        print(f'Value read with get() is {value}')
+
+        # When a parameter is set, the callback is called with the new value
+        self._cf.param.add_update_callback(group='pid_attitude', name='pitch_kd', cb=self._a_pitch_kd_callback)
+        # When setting a value the parameter is automatically read back
+        # and the registered callbacks will get the updated value
+        self._cf.param.set_value('pid_attitude.pitch_kd', 0.1234)
 
     def _cpu_flash_callback(self, name, value):
         """Specific callback for the cpu.flash parameter"""
@@ -101,35 +116,20 @@ class ParamExample:
         """Generic callback registered for all the groups"""
         print('{0}: {1}'.format(name, value))
 
-        # Remove each parameter from the list and close the link when
-        # all are fetched
+        # Remove each parameter from the list when fetched
         self._param_check_list.remove(name)
         if len(self._param_check_list) == 0:
             print('Have fetched all parameter values.')
 
-            # First remove all the group callbacks
+            # Remove all the group callbacks
             for g in self._param_groups:
-                self._cf.param.remove_update_callback(group=g,
-                                                      cb=self._param_callback)
-
-            # Create a new random value [0.00,1.00] for pid_attitude.pitch_kd
-            # and set it
-            pkd = random.random()
-            print('')
-            print('Write: pid_attitude.pitch_kd={:.2f}'.format(pkd))
-            self._cf.param.add_update_callback(group='pid_attitude',
-                                               name='pitch_kd',
-                                               cb=self._a_pitch_kd_callback)
-            # When setting a value the parameter is automatically read back
-            # and the registered callbacks will get the updated value
-            self._cf.param.set_value('pid_attitude.pitch_kd',
-                                     '{:.2f}'.format(pkd))
+                self._cf.param.remove_update_callback(group=g, cb=self._param_callback)
 
     def _a_pitch_kd_callback(self, name, value):
         """Callback for pid_attitude.pitch_kd"""
-        print('Readback: {0}={1}'.format(name, value))
+        print('Read back: {0}={1}'.format(name, value))
 
-        # End the example by closing the link (will cause the app to quit)
+        # This is the end of the example, close link
         self._cf.close_link()
 
     def _connection_failed(self, link_uri, msg):
@@ -150,21 +150,14 @@ class ParamExample:
 
 
 if __name__ == '__main__':
+    import logging
+    logging.getLogger().setLevel(logging.INFO)
     # Initialize the low-level drivers
     cflib.crtp.init_drivers()
-    # Scan for Crazyflies and use the first one found
-    print('Scanning interfaces for Crazyflies...')
-    available = cflib.crtp.scan_interfaces(address)
-    print('Crazyflies found:')
-    for i in available:
-        print(i[0])
+    pe = ParamExample(address)
 
-    if len(available) > 0:
-        pe = ParamExample(available[0][0])
-        # The Crazyflie lib doesn't contain anything to keep the application
-        # alive, so this is where your application should do something. In our
-        # case we are just waiting until we are disconnected.
-        while pe.is_connected:
-            time.sleep(1)
-    else:
-        print('No Crazyflies found, cannot run example')
+    # The Crazyflie lib doesn't contain anything to keep the application
+    # alive, so this is where your application should do something. In our
+    # case we are just waiting until we are disconnected.
+    while pe.is_connected:
+        time.sleep(1)

--- a/test/crazyflie/test_syncCrazyflie.py
+++ b/test/crazyflie/test_syncCrazyflie.py
@@ -26,7 +26,6 @@ from test.support.asyncCallbackCaller import AsyncCallbackCaller
 from unittest.mock import MagicMock
 
 from cflib.crazyflie import Crazyflie
-from cflib.crazyflie import Param
 from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
 from cflib.utils import uri_helper
 from cflib.utils.callbacks import Caller
@@ -41,6 +40,7 @@ class SyncCrazyflieTest(unittest.TestCase):
         self.cf_mock.connected = Caller()
         self.cf_mock.connection_failed = Caller()
         self.cf_mock.disconnected = Caller()
+        self.cf_mock.fully_connected = Caller()
 
         self.cf_mock.open_link = AsyncCallbackCaller(
             cb=self.cf_mock.connected,
@@ -54,11 +54,6 @@ class SyncCrazyflieTest(unittest.TestCase):
             delay=0.2
         )
         self.cf_mock.close_link = self.close_link_mock.trigger
-
-        # Mock the behaviour that param values are updated(downloaded) after connection
-        self.param_mock = MagicMock(spec=Param)
-        self.param_mock.all_updated = Caller()
-        self.cf_mock.param = self.param_mock
 
         # Register a callback to be called when connected. Use it to trigger a callback
         # to trigger the call to the param.all_updated() callback
@@ -233,10 +228,11 @@ class SyncCrazyflieTest(unittest.TestCase):
         self.assertEqual(0, len(self.cf_mock.connected.callbacks))
         self.assertEqual(0, len(self.cf_mock.connection_failed.callbacks))
         self.assertEqual(0, len(self.cf_mock.disconnected.callbacks))
-        self.assertEqual(0, len(self.param_mock.all_updated.callbacks))
+        self.assertEqual(0, len(self.cf_mock.fully_connected.callbacks))
 
     def _connected_callback(self, uri):
         AsyncCallbackCaller(
-            cb=self.param_mock.all_updated,
+            cb=self.cf_mock.fully_connected,
+            args=[self.uri],
             delay=0.2
         ).trigger()


### PR DESCRIPTION
The connection sequence when the python lib connects to a crazyflie is fairly lengthy and contains multiple steps. The most commonly used callback to determine if the connection is completed is the `connected` callback on the `Crazyflie` class, it works in most cases but causes some issues in relation to parameters. 

To prevent setting or getting parameter values before they are available there is an `Event` in `param.set_value()` and `param.get_value()` that blocks the calling thread until the values are available. This is all fine, unless set or get is called from the thread that is handling incoming events as it will stop handling of parameter values as well and dead lock the thread. 

A number of callbacks are called from the incoming event handler thread, including the `connected` callback. The `connected` callback is called after the parameter TOC has been downloaded, but before the actual parameter values are fetched which means we get a dead lock if parameter operations are carried out in the callback. 

This PR aims at fixing the problem by:
1. Raising an exception if get or set is called from the incoming event handing thread (that is a callback) before the parameters are available. This will notify the user of the problem rather than just freezing.
2. Adding a new callback on the Crazyflie class, it is called `fully_connected()` and is called after all parameters are downloaded which makes it OK to manipulate parameters when it is called.

There is a subtle change in the order that callbacks are called during the connection sequence (in theory an API break). in the Param class, the `all_update_callback()` will now be called after all parameter callbacks (if they were registered) have been called. Previously the `all_update_callback()` was called after all but one parameters, and after that the callback for the final parameter.

In some earlier versions of the python lib, it has been possible to call `param.set_value()` from the `connected` callback, this will now raise an exception. The solution is to use the `fully_connected` callback instead.

Fixes #341 