### PR TITLE
remove opencv from cflib

### DIFF
--- a/cflib/localization/lighthouse_bs_geo.py
+++ b/cflib/localization/lighthouse_bs_geo.py
@@ -104,7 +104,7 @@ class LighthouseBsGeoEstimator:
             raise Exception('OpenCV is not installed. To use this function,' +
                             'do "pip3 install opencv-python-headless"' +
                             ' and restart the cfclient')
-        
+
         guess_yaw = self._find_initial_yaw_guess(bs_vectors)
         rvec_guess, tvec_guess = self._convert_yaw_to_open_cv(guess_yaw)
         rw_ocv, tw_ocv = self._estimate_pose_by_pnp(bs_vectors, rvec_guess, tvec_guess)

--- a/cflib/localization/lighthouse_bs_geo.py
+++ b/cflib/localization/lighthouse_bs_geo.py
@@ -39,11 +39,12 @@ class LighthouseBsGeoEstimator:
     This class is used to estimate the geometry (position and attitude)
     of a lighthouse base station, given angles measured using a lighthouse deck.
     """
-
     def __init__(self):
+
+        self.lighthouse_bs_geo_estimator_available = True
+
         if OPENCV_INSTALLED is False:
-            raise Exception('OpenCV is not installed. To use this function,' +
-                            'do "pip3 install opencv-python-headless"')
+            self.lighthouse_bs_geo_estimator_available = False
 
         self._directions = {
             self._hash_sensor_order([2, 0, 1, 3]): math.radians(0),
@@ -86,6 +87,9 @@ class LighthouseBsGeoEstimator:
         # Sanity check maximum pos
         self._sanity_max_pos = 10
 
+    def is_lighthouse_bs_geo_estimator_available(self):
+        return self.lighthouse_bs_geo_estimator_available
+
     def estimate_geometry(self, bs_vectors):
         """
         Estimate the full pose of a base station based on angles from the 4 sensors
@@ -96,6 +100,12 @@ class LighthouseBsGeoEstimator:
         :return rot_bs_in_cf_coord: Rotation matrix of the BS in the CFs coordinate system
         :return pos_bs_in_cf_coord: Position vector of the BS in the CFs coordinate system
         """
+
+        if OPENCV_INSTALLED is False:
+            raise Exception('OpenCV is not installed. To use this function,' +
+                            'do "pip3 install opencv-python-headless"' +
+                            ' and restart the cfclient')
+        
         guess_yaw = self._find_initial_yaw_guess(bs_vectors)
         rvec_guess, tvec_guess = self._convert_yaw_to_open_cv(guess_yaw)
         rw_ocv, tw_ocv = self._estimate_pose_by_pnp(bs_vectors, rvec_guess, tvec_guess)

--- a/cflib/localization/lighthouse_bs_geo.py
+++ b/cflib/localization/lighthouse_bs_geo.py
@@ -33,6 +33,7 @@ else:
     import cv2 as cv
     OPENCV_INSTALLED = True
 
+
 class LighthouseBsGeoEstimator:
     """
     This class is used to estimate the geometry (position and attitude)
@@ -41,7 +42,7 @@ class LighthouseBsGeoEstimator:
 
     def __init__(self):
         if OPENCV_INSTALLED is False:
-            raise Exception('OpenCV is not installed. To use this function,' + 
+            raise Exception('OpenCV is not installed. To use this function,' +
                             'do "pip3 install opencv-python-headless"')
 
         self._directions = {

--- a/cflib/localization/lighthouse_bs_geo.py
+++ b/cflib/localization/lighthouse_bs_geo.py
@@ -42,9 +42,9 @@ class LighthouseBsGeoEstimator:
 
     def __init__(self):
 
-        self._lighthouse_bs_geo_estimator_available = True
+        self._estimator_available = True
         if OPENCV_INSTALLED is False:
-            self._lighthouse_bs_geo_estimator_available = False
+            self._estimator_available = False
 
         self._directions = {
             self._hash_sensor_order([2, 0, 1, 3]): math.radians(0),
@@ -87,8 +87,8 @@ class LighthouseBsGeoEstimator:
         # Sanity check maximum pos
         self._sanity_max_pos = 10
 
-    def is_lighthouse_bs_geo_estimator_available(self):
-        return self._lighthouse_bs_geo_estimator_available
+    def is_available(self):
+        return self._estimator_available
 
     def estimate_geometry(self, bs_vectors):
         """

--- a/cflib/localization/lighthouse_bs_geo.py
+++ b/cflib/localization/lighthouse_bs_geo.py
@@ -39,6 +39,7 @@ class LighthouseBsGeoEstimator:
     This class is used to estimate the geometry (position and attitude)
     of a lighthouse base station, given angles measured using a lighthouse deck.
     """
+
     def __init__(self):
 
         self._lighthouse_bs_geo_estimator_available = True

--- a/cflib/localization/lighthouse_bs_geo.py
+++ b/cflib/localization/lighthouse_bs_geo.py
@@ -41,10 +41,9 @@ class LighthouseBsGeoEstimator:
     """
     def __init__(self):
 
-        self.lighthouse_bs_geo_estimator_available = True
-
+        self._lighthouse_bs_geo_estimator_available = True
         if OPENCV_INSTALLED is False:
-            self.lighthouse_bs_geo_estimator_available = False
+            self._lighthouse_bs_geo_estimator_available = False
 
         self._directions = {
             self._hash_sensor_order([2, 0, 1, 3]): math.radians(0),
@@ -88,7 +87,7 @@ class LighthouseBsGeoEstimator:
         self._sanity_max_pos = 10
 
     def is_lighthouse_bs_geo_estimator_available(self):
-        return self.lighthouse_bs_geo_estimator_available
+        return self._lighthouse_bs_geo_estimator_available
 
     def estimate_geometry(self, bs_vectors):
         """

--- a/cflib/localization/lighthouse_bs_geo.py
+++ b/cflib/localization/lighthouse_bs_geo.py
@@ -24,9 +24,14 @@ Functionality to handle base station geometry in the lighthouse poistioning syst
 """
 import math
 
-import cv2 as cv
 import numpy as np
-
+import pkg_resources
+installed = {pkg.key for pkg in pkg_resources.working_set}
+if {'opencv-python-headless'} - installed:
+    OPENCV_INSTALLED = False
+else:
+    import cv2 as cv
+    OPENCV_INSTALLED = True
 
 class LighthouseBsGeoEstimator:
     """
@@ -35,6 +40,10 @@ class LighthouseBsGeoEstimator:
     """
 
     def __init__(self):
+        if OPENCV_INSTALLED is False:
+            raise Exception('OpenCV is not installed. To use this function,' + 
+                            'do "pip3 install opencv-python-headless"')
+
         self._directions = {
             self._hash_sensor_order([2, 0, 1, 3]): math.radians(0),
             self._hash_sensor_order([2, 0, 3, 1]): math.radians(25),

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         'libusb-package~=1.0',
         'scipy~=1.7',
         'numpy>=1.20,<1.25',
-        'opencv-python-headless~=4.5.5'
     ],
 
     # $ pip install -e .[dev]


### PR DESCRIPTION
A proposal to check in the cflib if opencv is installed an do an except if not. 

The idea is to do approximately the same in the cfclient:

```
import pkg_resources
installed = {pkg.key for pkg in pkg_resources.working_set}
if {'opencv-python-headless'} - installed:
    OPENCV_INSTALLED = False
else:
    OPENCV_INSTALLED = True

```

and gray out the geometry opencv button if not installed.

I propose this to more or less not be as breaking case. In case person has an older cfclient but the latest cflib they get an exception (which won't close the client), and if they are up to date, the button will be gray outed.

This is towards closing this issue: https://github.com/bitcraze/crazyflie-clients-python/issues/611