### PR TITLE
Increase LH sample match time

### DIFF
--- a/cflib/localization/lighthouse_sample_matcher.py
+++ b/cflib/localization/lighthouse_sample_matcher.py
@@ -34,7 +34,7 @@ class LighthouseSampleMatcher:
     """
 
     @classmethod
-    def match(cls, samples: list[LhMeasurement], max_time_diff: float = 0.010,
+    def match(cls, samples: list[LhMeasurement], max_time_diff: float = 0.020,
               min_nr_of_bs_in_match: int = 0) -> list[LhCfPoseSample]:
         """
         Aggregate samples close in time into lists


### PR DESCRIPTION
The time used to group samples in the lighthouse geometry estimator works well for LH2 systems, but seems to be too short  for LH1. This PR increases it to work for both types.

This will improve functionality for LH1 where it sometimes has been hard to get a proper geometry estimation.