### PR TITLE
Add outlier filter to LH geo estimation

### DIFF
--- a/examples/lighthouse/multi_bs_geometry_estimation.py
+++ b/examples/lighthouse/multi_bs_geometry_estimation.py
@@ -212,14 +212,16 @@ def estimate_geometry(origin: LhCfPoseSample,
                       samples: list[LhCfPoseSample]) -> dict[int, Pose]:
     """Estimate the geometry of the system based on samples recorded by a Crazyflie"""
     matched_samples = [origin] + x_axis + xy_plane + LighthouseSampleMatcher.match(samples, min_nr_of_bs_in_match=2)
-    initial_guess = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
+    initial_guess, cleaned_matched_samples = LighthouseInitialEstimator.estimate(
+        matched_samples, LhDeck4SensorPositions.positions)
 
     print('Initial guess base stations at:')
     print_base_stations_poses(initial_guess.bs_poses)
-    visualize(initial_guess.cf_poses, initial_guess.bs_poses.values())
-    print(f'{len(matched_samples)} samples will be used')
 
-    solution = LighthouseGeometrySolver.solve(initial_guess, matched_samples, LhDeck4SensorPositions.positions)
+    print(f'{len(cleaned_matched_samples)} samples will be used')
+    visualize(initial_guess.cf_poses, initial_guess.bs_poses.values())
+
+    solution = LighthouseGeometrySolver.solve(initial_guess, cleaned_matched_samples, LhDeck4SensorPositions.positions)
     if not solution.success:
         print('Solution did not converge, it might not be good!')
 

--- a/test/localization/test_lighthouse_geometry_solver.py
+++ b/test/localization/test_lighthouse_geometry_solver.py
@@ -44,11 +44,12 @@ class TestLighthouseGeometrySolver(LighthouseTestBase):
             }),
         ]
 
-        initial_guess = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
+        initial_guess, cleaned_matched_samples = LighthouseInitialEstimator.estimate(matched_samples,
+                                                                                     LhDeck4SensorPositions.positions)
 
         # Test
         actual = LighthouseGeometrySolver.solve(
-            initial_guess, matched_samples, LhDeck4SensorPositions.positions)
+            initial_guess, cleaned_matched_samples, LhDeck4SensorPositions.positions)
 
         # Assert
         bs_poses = actual.bs_poses
@@ -77,11 +78,12 @@ class TestLighthouseGeometrySolver(LighthouseTestBase):
             }),
         ]
 
-        initial_guess = LighthouseInitialEstimator.estimate(matched_samples, LhDeck4SensorPositions.positions)
+        initial_guess, cleaned_matched_samples = LighthouseInitialEstimator.estimate(matched_samples,
+                                                                                     LhDeck4SensorPositions.positions)
 
         # Test
         actual = LighthouseGeometrySolver.solve(
-            initial_guess, matched_samples, LhDeck4SensorPositions.positions)
+            initial_guess, cleaned_matched_samples, LhDeck4SensorPositions.positions)
 
         # Assert
         bs_poses = actual.bs_poses

--- a/test/localization/test_lighthouse_initial_estimator.py
+++ b/test/localization/test_lighthouse_initial_estimator.py
@@ -60,7 +60,7 @@ class TestLighthouseInitialEstimator(LighthouseTestBase):
         ]
 
         # Test
-        actual = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
+        actual, cleaned_samples = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
 
         # Assert
         self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, actual.bs_poses[bs_id0], places=3)
@@ -89,7 +89,7 @@ class TestLighthouseInitialEstimator(LighthouseTestBase):
         ]
 
         # Test
-        actual = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
+        actual, cleaned_samples = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
 
         # Assert
         self.assertPosesAlmostEqual(self.fixtures.BS0_POSE, actual.bs_poses[bs_id0], places=3)
@@ -120,7 +120,7 @@ class TestLighthouseInitialEstimator(LighthouseTestBase):
         ]
 
         # Test
-        actual = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
+        actual, cleaned_samples = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
 
         # Assert
         self.assertPosesAlmostEqual(self.fixtures.CF_ORIGIN_POSE, actual.cf_poses[0], places=3)
@@ -145,7 +145,7 @@ class TestLighthouseInitialEstimator(LighthouseTestBase):
         ]
 
         # Test
-        actual = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
+        actual, cleaned_samples = LighthouseInitialEstimator.estimate(samples, LhDeck4SensorPositions.positions)
 
         # Assert
         self.assertPosesAlmostEqual(


### PR DESCRIPTION
This pull request improves the lighthouse geometry estimation. It adds an outlier filter when estimating the initial guess. 
In some cases (mainly LH1) the initial guess could contain too many outliers, causing the refinement step to never converge.