### PR TITLE
Avoid possible deadlock in param

### DIFF
--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -33,7 +33,7 @@ import errno
 import logging
 import struct
 from collections import namedtuple
-from queue import Queue
+from queue import Queue, Empty
 from threading import Event
 from threading import Lock
 from threading import Thread
@@ -556,13 +556,17 @@ class _ExtendedTypeFetcher(Thread):
 
     def _close(self):
         # First empty the queue from all packets
-        while not self.request_queue.empty():
-            self.request_queue.get()
+        try:
+            while True:
+                self.request_queue.get(block=False)
+        except Empty:
+            pass
+
         # Then force an unlock of the mutex if we are waiting for a packet
         # we didn't get back due to a disconnect for example.
         try:
             self._lock.release()
-        except Exception:
+        except RuntimeError:
             pass
 
     def run(self):
@@ -595,13 +599,17 @@ class _ParamUpdater(Thread):
 
     def close(self):
         # First empty the queue from all packets
-        while not self.request_queue.empty():
-            self.request_queue.get()
+        try:
+            while True:
+                self.request_queue.get(block=False)
+        except Empty:
+            pass
+
         # Then force an unlock of the mutex if we are waiting for a packet
         # we didn't get back due to a disconnect for example.
         try:
             self.wait_lock.release()
-        except Exception:
+        except RuntimeError:
             pass
 
     def request_param_setvalue(self, pk):

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -33,7 +33,8 @@ import errno
 import logging
 import struct
 from collections import namedtuple
-from queue import Queue, Empty
+from queue import Empty
+from queue import Queue
 from threading import Event
 from threading import Lock
 from threading import Thread


### PR DESCRIPTION
This PR avoids the possible deadlock in params when closing the connection by not blocking when poping the queues.

Fixes #368