### PR TITLE
Include start and size when for CPX UART CRC RX

### DIFF
--- a/cflib/cpx/transports.py
+++ b/cflib/cpx/transports.py
@@ -140,7 +140,9 @@ class UARTTransport(CPXTransport):
                 else:
                     data = self._serial.read(size)  # Size is excluding start (0xFF) and checksum at end
                     crc = self._serial.read(1)
-                    if self._calcXORchecksum(data) != crc:
+                    # CRC includes start and size
+                    calculated_crc = self._calcXORchecksum(bytes([start, size]) + data)
+                    if calculated_crc != ord(crc):
                         print('CRC error!')
                     # Send CTS
                     self._serial.write([0xFF, 0x00])


### PR DESCRIPTION
The UART transport for CPX dit not use start and size for CRC calculations when receiving data. This change fixes it