### PR TITLE
Removed use of commander.enHighLevel

### DIFF
--- a/cflib/positioning/position_hl_commander.py
+++ b/cflib/positioning/position_hl_commander.py
@@ -74,7 +74,6 @@ class PositionHlCommander:
         self._controller = controller
 
         self._activate_controller()
-        self._activate_high_level_commander()
         self._hl_commander = self._cf.high_level_commander
 
         self._x = x
@@ -277,9 +276,6 @@ class PositionHlCommander:
         :return: (x, y, z)
         """
         return self._x, self._y, self._z
-
-    def _activate_high_level_commander(self):
-        self._cf.param.set_value('commander.enHighLevel', '1')
 
     def _activate_controller(self):
         if self._controller is not None:

--- a/examples/autonomy/autonomous_sequence_high_level.py
+++ b/examples/autonomy/autonomous_sequence_high_level.py
@@ -111,10 +111,6 @@ def reset_estimator(cf):
     wait_for_position_estimator(cf)
 
 
-def activate_high_level_commander(cf):
-    cf.param.set_value('commander.enHighLevel', '1')
-
-
 def activate_mellinger_controller(cf):
     cf.param.set_value('stabilizer.controller', '2')
 
@@ -161,7 +157,6 @@ if __name__ == '__main__':
         cf = scf.cf
         trajectory_id = 1
 
-        activate_high_level_commander(cf)
         # activate_mellinger_controller(cf)
         duration = upload_trajectory(cf, trajectory_id, figure8)
         print('The sequence is {:.1f} seconds long'.format(duration))

--- a/examples/autonomy/autonomous_sequence_high_level_compressed.py
+++ b/examples/autonomy/autonomous_sequence_high_level_compressed.py
@@ -107,10 +107,6 @@ def reset_estimator(cf):
     wait_for_position_estimator(cf)
 
 
-def activate_high_level_commander(cf):
-    cf.param.set_value('commander.enHighLevel', '1')
-
-
 def activate_mellinger_controller(cf):
     cf.param.set_value('stabilizer.controller', '2')
 
@@ -158,7 +154,6 @@ if __name__ == '__main__':
         cf = scf.cf
         trajectory_id = 1
 
-        activate_high_level_commander(cf)
         # activate_mellinger_controller(cf)
         duration = upload_trajectory(cf, trajectory_id, trajectory)
         print('The sequence is {:.1f} seconds long'.format(duration))

--- a/examples/qualisys/qualisys_hl_commander.py
+++ b/examples/qualisys/qualisys_hl_commander.py
@@ -240,10 +240,6 @@ def activate_kalman_estimator(cf):
     cf.param.set_value('locSrv.extQuatStdDev', 0.06)
 
 
-def activate_high_level_commander(cf):
-    cf.param.set_value('commander.enHighLevel', '1')
-
-
 def activate_mellinger_controller(cf):
     cf.param.set_value('stabilizer.controller', '2')
 
@@ -296,7 +292,6 @@ if __name__ == '__main__':
 
         adjust_orientation_sensitivity(cf)
         activate_kalman_estimator(cf)
-        activate_high_level_commander(cf)
         # activate_mellinger_controller(cf)
         duration = upload_trajectory(cf, trajectory_id, figure8)
         print('The sequence is {:.1f} seconds long'.format(duration))

--- a/examples/swarm/hl-commander-swarm.py
+++ b/examples/swarm/hl-commander-swarm.py
@@ -37,10 +37,6 @@ from cflib.crazyflie.swarm import CachedCfFactory
 from cflib.crazyflie.swarm import Swarm
 
 
-def activate_high_level_commander(scf):
-    scf.cf.param.set_value('commander.enHighLevel', '1')
-
-
 def activate_mellinger_controller(scf, use_mellinger):
     controller = 1
     if use_mellinger:
@@ -87,6 +83,5 @@ if __name__ == '__main__':
     cflib.crtp.init_drivers()
     factory = CachedCfFactory(rw_cache='./cache')
     with Swarm(uris, factory=factory) as swarm:
-        swarm.parallel_safe(activate_high_level_commander)
         swarm.reset_estimators()
         swarm.parallel_safe(run_shared_sequence)

--- a/examples/swarm/synchronizedSequence.py
+++ b/examples/swarm/synchronizedSequence.py
@@ -98,10 +98,6 @@ sequence = [
 ]
 
 
-def activate_high_level_commander(scf):
-    scf.cf.param.set_value('commander.enHighLevel', '1')
-
-
 def activate_mellinger_controller(scf, use_mellinger):
     controller = 1
     if use_mellinger:
@@ -185,7 +181,6 @@ if __name__ == '__main__':
     cflib.crtp.init_drivers()
     factory = CachedCfFactory(rw_cache='./cache')
     with Swarm(uris, factory=factory) as swarm:
-        swarm.parallel_safe(activate_high_level_commander)
         swarm.reset_estimators()
 
         print('Starting sequence!')

--- a/examples/tuning/PID_controller_tuner.py
+++ b/examples/tuning/PID_controller_tuner.py
@@ -174,7 +174,6 @@ class TunerControlCF:
         self.update_scale_info()
 
         self.commander = cf.high_level_commander
-        self.cf.param.set_value('commander.enHighLevel', '1')
         self.take_off(STANDARD_HEIGHT)
 
     def update_scale_info(self):

--- a/test/positioning/test_position_hl_commander.py
+++ b/test/positioning/test_position_hl_commander.py
@@ -43,17 +43,6 @@ class TestPositionHlCommander(unittest.TestCase):
 
         self.sut = PositionHlCommander(self.cf_mock)
 
-    def test_that_the_hi_level_commander_is_activated_on_creation(
-            self, sleep_mock):
-        # Fixture
-
-        # Test
-
-        # Assert
-        self.param_mock.set_value.assert_has_calls([
-            call('commander.enHighLevel', '1')
-        ])
-
     def test_that_controller_is_selected_on_creation(
             self, sleep_mock):
         # Fixture


### PR DESCRIPTION
Remove use of the parameter `commander.enHighLevel`.

This parameter [is not used any more](https://github.com/bitcraze/crazyflie-firmware/pull/903)

Closes #379