### PR TITLE
Fix deck flashing

### DIFF
--- a/cflib/bootloader/__init__.py
+++ b/cflib/bootloader/__init__.py
@@ -424,7 +424,12 @@ class Bootloader:
                     time.sleep(2)
                     raise RuntimeError(message)
 
-            for (deck_index, deck) in decks.items():
+            # The decks dictionary uses the deck index as the key. Note that all indexes might not be present as some
+            # decks do not support memory operations. decks.keys() might return the set {2, 4}.
+
+            for deck_index in sorted(decks.keys()):
+                deck = decks[deck_index]
+
                 if self.terminate_flashing_cb and self.terminate_flashing_cb():
                     raise Exception('Flashing terminated')
 
@@ -508,8 +513,6 @@ class Bootloader:
 
                 # We flashed a deck, return for re-boot
                 next_index = deck_index + 1
-                if next_index >= len(decks):
-                    next_index = -1
                 return next_index
 
             # We have flashed the last deck

--- a/cflib/crazyflie/mem/deck_memory.py
+++ b/cflib/crazyflie/mem/deck_memory.py
@@ -182,9 +182,10 @@ class DeckMemoryManager(MemoryElement):
     """
 
     MAX_NR_OF_DECKS = 4
+    MAX_NR_OF_DECK_MEM_INFOS = MAX_NR_OF_DECKS * 2
     SIZE_OF_DECK_MEM_INFO = 0x20
     SIZE_OF_VERSION = 1
-    SIZE_OF_INFO_SECTION = SIZE_OF_VERSION + MAX_NR_OF_DECKS * SIZE_OF_DECK_MEM_INFO
+    SIZE_OF_INFO_SECTION = SIZE_OF_VERSION + MAX_NR_OF_DECK_MEM_INFOS * SIZE_OF_DECK_MEM_INFO
     INFO_SECTION_ADDRESS = 0
     COMMAND_SECTION_ADDRESS = 0x1000
     SIZE_OF_COMMAND_SECTION = 0x20
@@ -276,7 +277,7 @@ class DeckMemoryManager(MemoryElement):
         if version != self.SUPPORTED_VERSION:
             raise RuntimeError(f'Deck memory version {version} not supported')
         else:
-            for i in range(self.MAX_NR_OF_DECKS):
+            for i in range(self.MAX_NR_OF_DECK_MEM_INFOS):
                 deck_memory = DeckMemory(self, self.COMMAND_SECTION_ADDRESS + i * self.SIZE_OF_COMMAND_SECTION)
                 start = self.SIZE_OF_VERSION + self.SIZE_OF_DECK_MEM_INFO * i
                 end = start + self.SIZE_OF_DECK_MEM_INFO


### PR DESCRIPTION
This PR fixes problems related to deck flashing.
* The reading of deck memory info sections only looked at the 2 first decks out of 4
* The deck indexing in the flashing stage could potentially skip decks depending on deck ids