### PR TITLE
Call send_notify_setpoint_stop()

### DIFF
--- a/examples/autonomy/autonomousSequence.py
+++ b/examples/autonomy/autonomousSequence.py
@@ -137,6 +137,9 @@ def run_sequence(scf, sequence):
             time.sleep(0.1)
 
     cf.commander.send_stop_setpoint()
+    # Hand control over to the high level commander to avoid timeout and locking of the Crazyflie
+    cf.commander.send_notify_setpoint_stop()
+
     # Make sure that the last packet leaves before the link is closed
     # since the message queue is not flushed before closing
     time.sleep(0.1)

--- a/examples/positioning/flowsequenceSync.py
+++ b/examples/positioning/flowsequenceSync.py
@@ -79,3 +79,5 @@ if __name__ == '__main__':
             time.sleep(0.1)
 
         cf.commander.send_stop_setpoint()
+        # Hand control over to the high level commander to avoid timeout and locking of the Crazyflie
+        cf.commander.send_notify_setpoint_stop()

--- a/examples/positioning/initial_position.py
+++ b/examples/positioning/initial_position.py
@@ -130,6 +130,9 @@ def run_sequence(scf, sequence, base_x, base_y, base_z, yaw):
             time.sleep(0.1)
 
     cf.commander.send_stop_setpoint()
+    # Hand control over to the high level commander to avoid timeout and locking of the Crazyflie
+    cf.commander.send_notify_setpoint_stop()
+
     # Make sure that the last packet leaves before the link is closed
     # since the message queue is not flushed before closing
     time.sleep(0.1)

--- a/examples/swarm/swarmSequence.py
+++ b/examples/swarm/swarmSequence.py
@@ -197,6 +197,9 @@ def land(cf, position):
         time.sleep(sleep_time)
 
     cf.commander.send_stop_setpoint()
+    # Hand control over to the high level commander to avoid timeout and locking of the Crazyflie
+    cf.commander.send_notify_setpoint_stop()
+
     # Make sure that the last packet leaves before the link is closed
     # since the message queue is not flushed before closing
     time.sleep(0.1)

--- a/examples/swarm/swarmSequenceCircle.py
+++ b/examples/swarm/swarmSequenceCircle.py
@@ -129,6 +129,8 @@ def run_sequence(scf, params):
     poshold(cf, 1, base)
 
     cf.commander.send_stop_setpoint()
+    # Hand control over to the high level commander to avoid timeout and locking of the Crazyflie
+    cf.commander.send_notify_setpoint_stop()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Since the re-work of the supervisor, the behavior of some scripts has changed. When sending setpoints and then calling `send_stop_setpoint()` will lock up the Crazyfile after a time out and a restart is required to run the script again (see https://github.com/bitcraze/crazyflie-firmware/issues/1297). The reason is that no more set points are sent from the client (script) and the firmware interprets this as the connection is lost. By calling the `send_notify_setpoint_stop()` function we tell the the firmware to switch back to the high level commander and the time out will not happen. 

This PR updates some example scripts and adds a call to `send_notify_setpoint_stop()` to make it possible to run them over and over again