### PR TITLE
Update sbs_connect_log_param.md

### DIFF
--- a/docs/user-guides/sbs_connect_log_param.md
+++ b/docs/user-guides/sbs_connect_log_param.md
@@ -248,7 +248,7 @@ uri = 'radio://0/80/2M/E7E7E7E7E7'
 # Only output errors from the logging framework
 logging.basicConfig(level=logging.ERROR)
 
-def simple_log(scf, logconf):
+def simple_log(scf, lg_stab):
 
     with SyncLogger(scf, lg_stab) as logger:
 


### PR DESCRIPTION
simple_log function has wrong parameter logconf, which is not be used in the simple_log, the parameter name should be 'lg_stab' or change 'lg_stab' var as 'logconf' instead