### PR TITLE
Added usage message for radio-test

### DIFF
--- a/examples/radio/radio-test.py
+++ b/examples/radio/radio-test.py
@@ -9,7 +9,7 @@
     quality data, and offers good channel suggestion.
 
     This script should be used on a Crazyflie with bluetooth disabled and RSSI
-    ack packet enabled to get RSSI feedback.  To configure the Crazyflie in this
+    ack packet enabled to get RSSI feedback. To configure the Crazyflie in this
     mode build the crazyflie2-nrf-firmware with
     ```make BLE=0 CONFIG=-DRSSI_ACK_PACKET```.
     Additionally, the Crazyflie must be using the default address 0xE7E7E7E7E7.

--- a/examples/radio/radio-test.py
+++ b/examples/radio/radio-test.py
@@ -9,9 +9,10 @@
     quality data, and offers good channel suggestion.
 
     This script should be used on a Crazyflie with bluetooth disabled and RSSI
-    ack packet enabled to get RSSI feedback. To configure the Crazyflie in this
+    ack packet enabled to get RSSI feedback.  To configure the Crazyflie in this
     mode build the crazyflie2-nrf-firmware with
     ```make BLE=0 CONFIG=-DRSSI_ACK_PACKET```.
+    Additionally, the Crazyflie must be using the default address 0xE7E7E7E7E7.
     See https://github.com/bitcraze/crazyflie-lib-python/issues/131 for more
     informations.
 '''


### PR DESCRIPTION
It took me a while to figure out what I was doing wrong when trying to use the `radio-test.py` script.  I added a small usage comment to prevent other users from running into the same issue.  