### PR TITLE
Implement persistent parameter file management

### DIFF
--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -445,6 +445,9 @@ class Param():
         @param callback Optional callback should take `complete_name` and boolean status as arguments
         """
         element = self.toc.get_element_by_complete_name(complete_name)
+        if not element:
+            callback(complete_name, False)
+            return
         if not element.is_persistent():
             raise AttributeError(f"Param '{complete_name}' is not persistent")
 

--- a/cflib/localization/__init__.py
+++ b/cflib/localization/__init__.py
@@ -25,6 +25,7 @@ from .lighthouse_config_manager import LighthouseConfigFileManager
 from .lighthouse_config_manager import LighthouseConfigWriter
 from .lighthouse_sweep_angle_reader import LighthouseSweepAngleAverageReader
 from .lighthouse_sweep_angle_reader import LighthouseSweepAngleReader
+from .param_io import ParamFileManager
 
 __all__ = [
     'LighthouseBsGeoEstimator',
@@ -32,4 +33,5 @@ __all__ = [
     'LighthouseSweepAngleAverageReader',
     'LighthouseSweepAngleReader',
     'LighthouseConfigFileManager',
-    'LighthouseConfigWriter']
+    'LighthouseConfigWriter',
+    'ParamFileManager']

--- a/cflib/localization/param_io.py
+++ b/cflib/localization/param_io.py
@@ -27,7 +27,7 @@ from cflib.crazyflie.param import Param, PersistentParamState
 class ParamFileManager():
     """Reads and writes parameter configurations from file"""
     TYPE_ID = 'type'
-    TYPE = 'param_system_configuration'
+    TYPE = 'persistent_param_state'
     VERSION_ID = 'version'
     VERSION = '1'
     PARAMS_ID = 'params'

--- a/cflib/localization/param_io.py
+++ b/cflib/localization/param_io.py
@@ -22,7 +22,7 @@
 
 import yaml
 
-from cflib.crazyflie.param import Param, PersistentParamState
+from cflib.crazyflie.param import PersistentParamState
 
 class ParamFileManager():
     """Reads and writes parameter configurations from file"""

--- a/cflib/localization/param_io.py
+++ b/cflib/localization/param_io.py
@@ -19,10 +19,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-
 import yaml
 
 from cflib.crazyflie.param import PersistentParamState
+
 
 class ParamFileManager():
     """Reads and writes parameter configurations from file"""
@@ -40,7 +40,8 @@ class ParamFileManager():
             for id, param in params.items():
                 assert isinstance(param, PersistentParamState)
                 if isinstance(param, PersistentParamState):
-                    file_params[id] = {'is_stored': param.is_stored, 'default_value': param.default_value, 'stored_value': param.stored_value}
+                    file_params[id] = {'is_stored': param.is_stored,
+                                       'default_value': param.default_value, 'stored_value': param.stored_value}
 
             data = {
                 ParamFileManager.TYPE_ID: ParamFileManager.TYPE,
@@ -49,7 +50,7 @@ class ParamFileManager():
             }
 
             yaml.dump(data, file)
-    
+
     @staticmethod
     def read(file_name):
         file = open(file_name, 'r')
@@ -71,13 +72,14 @@ class ParamFileManager():
 
             if data[ParamFileManager.VERSION_ID] != ParamFileManager.VERSION:
                 raise Exception('Unsupported file version')
-            
+
             def get_data(input_data):
                 persistent_params = {}
                 for id, param in input_data.items():
-                    persistent_params[id] = PersistentParamState(param['is_stored'], param['default_value'], param['stored_value'])
+                    persistent_params[id] = PersistentParamState(
+                        param['is_stored'], param['default_value'], param['stored_value'])
                 return persistent_params
-            
+
             if ParamFileManager.PARAMS_ID in data:
                 return get_data(data[ParamFileManager.PARAMS_ID])
             else:

--- a/cflib/localization/param_io.py
+++ b/cflib/localization/param_io.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2024 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import yaml
+
+from cflib.crazyflie.param import Param, PersistentParamState
+
+class ParamFileManager():
+    """Reads and writes parameter configurations from file"""
+    TYPE_ID = 'type'
+    TYPE = 'param_system_configuration'
+    VERSION_ID = 'version'
+    VERSION = '1'
+    PARAMS_ID = 'params'
+
+    @staticmethod
+    def write(file_name, params={}):
+        file = open(file_name, 'w')
+        with file:
+            file_params = {}
+            for id, param in params.items():
+                assert isinstance(param, PersistentParamState)
+                if isinstance(param, PersistentParamState):
+                    if param.is_stored:
+                        file_params[id] = {'is_stored': param.is_stored, 'default_value': param.default_value, 'stored_value': param.stored_value}
+
+            data = {
+                ParamFileManager.TYPE_ID: ParamFileManager.TYPE,
+                ParamFileManager.VERSION_ID: ParamFileManager.VERSION,
+                ParamFileManager.PARAMS_ID: file_params
+            }
+
+            yaml.dump(data, file)
+    
+    @staticmethod
+    def read(file_name):
+        file = open(file_name, 'r')
+        with file:
+            data = None
+            try:
+                data = yaml.safe_load(file)
+            except yaml.YAMLError as exc:
+                print(exc)
+
+            if ParamFileManager.TYPE_ID not in data:
+                raise Exception('Type field missing')
+
+            if data[ParamFileManager.TYPE_ID] != ParamFileManager.TYPE:
+                raise Exception('Unsupported file type')
+
+            if ParamFileManager.VERSION_ID not in data:
+                raise Exception('Version field missing')
+
+            if data[ParamFileManager.VERSION_ID] != ParamFileManager.VERSION:
+                raise Exception('Unsupported file version')
+            
+            def get_data(input_data):
+                persistent_params = {}
+                for id, param in input_data.items():
+                    persistent_params[id] = PersistentParamState(param['is_stored'], param['default_value'], param['stored_value'])
+                return persistent_params
+            
+            if ParamFileManager.PARAMS_ID in data:
+                return get_data(data[ParamFileManager.PARAMS_ID])
+            else:
+                return {}

--- a/cflib/localization/param_io.py
+++ b/cflib/localization/param_io.py
@@ -40,8 +40,7 @@ class ParamFileManager():
             for id, param in params.items():
                 assert isinstance(param, PersistentParamState)
                 if isinstance(param, PersistentParamState):
-                    if param.is_stored:
-                        file_params[id] = {'is_stored': param.is_stored, 'default_value': param.default_value, 'stored_value': param.stored_value}
+                    file_params[id] = {'is_stored': param.is_stored, 'default_value': param.default_value, 'stored_value': param.stored_value}
 
             data = {
                 ParamFileManager.TYPE_ID: ParamFileManager.TYPE,

--- a/test/localization/fixtures/parameters.yaml
+++ b/test/localization/fixtures/parameters.yaml
@@ -11,5 +11,5 @@ params:
     default_value: 0.4000000059604645
     is_stored: true
     stored_value: 0.44999998807907104
-type: param_system_configuration
+type: persistent_param_state
 version: '1'

--- a/test/localization/fixtures/parameters.yaml
+++ b/test/localization/fixtures/parameters.yaml
@@ -1,0 +1,15 @@
+params:
+  activeMarker.back:
+    default_value: 3
+    is_stored: true
+    stored_value: 10
+  cppm.angPitch:
+    default_value: 50.0
+    is_stored: true
+    stored_value: 55.0
+  ctrlMel.i_range_z:
+    default_value: 0.4000000059604645
+    is_stored: true
+    stored_value: 0.44999998807907104
+type: param_system_configuration
+version: '1'

--- a/test/localization/test_param_io.py
+++ b/test/localization/test_param_io.py
@@ -32,7 +32,7 @@ from cflib.localization import ParamFileManager
 class TestParamFileManager(unittest.TestCase):
     def setUp(self):
         self.data = {
-            'type': 'param_system_configuration',
+            'type': 'persistent_param_state',
             'version': '1',
         }
 

--- a/test/localization/test_param_io.py
+++ b/test/localization/test_param_io.py
@@ -19,7 +19,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-
 import unittest
 from unittest.mock import ANY
 from unittest.mock import mock_open
@@ -28,6 +27,7 @@ from unittest.mock import patch
 import yaml
 
 from cflib.localization import ParamFileManager
+
 
 class TestParamFileManager(unittest.TestCase):
     def setUp(self):
@@ -48,7 +48,7 @@ class TestParamFileManager(unittest.TestCase):
 
         # Assert
         mock_file.assert_called_with(file_name, 'r')
-        
+
     @patch('yaml.safe_load')
     def test_that_missing_file_type_raises(self, mock_yaml_load):
         # Fixture
@@ -85,7 +85,7 @@ class TestParamFileManager(unittest.TestCase):
         with self.assertRaises(Exception):
             with patch('builtins.open', new_callable=mock_open()):
                 ParamFileManager.read('some/name.yaml')
-    
+
     @patch('yaml.safe_load')
     def test_that_wrong_version_raises(self, mock_yaml_load):
         # Fixture
@@ -106,10 +106,10 @@ class TestParamFileManager(unittest.TestCase):
         # Test
         with patch('builtins.open', new_callable=mock_open()):
             actual_params = ParamFileManager.read('some/name.yaml')
-        
+
         # Assert
         self.assertEqual(0, len(actual_params))
-    
+
     @patch('yaml.dump')
     def test_file_end_to_end_write_read(self, mock_yaml_dump):
         # Fixture
@@ -126,7 +126,7 @@ class TestParamFileManager(unittest.TestCase):
 
             # Assert
             mock_yaml_dump.assert_called_with(expected, ANY)
-    
+
     @patch('yaml.dump')
     def test_file_write_to_correct_file(self, mock_yaml_dump):
         # Fixture

--- a/test/localization/test_param_io.py
+++ b/test/localization/test_param_io.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2024 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import ANY
+from unittest.mock import mock_open
+from unittest.mock import patch
+
+import yaml
+
+from cflib.localization import ParamFileManager
+
+class TestParamFileManager(unittest.TestCase):
+    def setUp(self):
+        self.data = {
+            'type': 'param_system_configuration',
+            'version': '1',
+        }
+
+    @patch('yaml.safe_load')
+    def test_that_read_open_correct_file(self, mock_yaml_load):
+        # Fixture
+        mock_yaml_load.return_value = self.data
+        file_name = 'some/name.yaml'
+
+        # Test
+        with patch('builtins.open', new_callable=mock_open()) as mock_file:
+            ParamFileManager.read(file_name)
+
+        # Assert
+        mock_file.assert_called_with(file_name, 'r')
+        
+    @patch('yaml.safe_load')
+    def test_that_missing_file_type_raises(self, mock_yaml_load):
+        # Fixture
+        self.data.pop('type')
+        mock_yaml_load.return_value = self.data
+
+        # Test
+        # Assert
+        with self.assertRaises(Exception):
+            with patch('builtins.open', new_callable=mock_open()):
+                ParamFileManager.read('some/name.yaml')
+
+    @patch('yaml.safe_load')
+    def test_that_wrong_file_type_raises(self, mock_yaml_load):
+        # Fixture
+        self.data['type'] = 'wrong_type'
+        mock_yaml_load.return_value = self.data
+
+        # Test
+        # Assert
+        with self.assertRaises(Exception):
+            with patch('builtins.open', new_callable=mock_open()):
+                ParamFileManager.read('some/name.yaml')
+
+    @patch('yaml.safe_load')
+    def test_that_missing_version_raises(self, mock_yaml_load):
+
+        # Fixture
+        self.data.pop('version')
+        mock_yaml_load.return_value = self.data
+
+        # Test
+        # Assert
+        with self.assertRaises(Exception):
+            with patch('builtins.open', new_callable=mock_open()):
+                ParamFileManager.read('some/name.yaml')
+    
+    @patch('yaml.safe_load')
+    def test_that_wrong_version_raises(self, mock_yaml_load):
+        # Fixture
+        self.data['version'] = 'wrong_version'
+        mock_yaml_load.return_value = self.data
+
+        # Test
+        # Assert
+        with self.assertRaises(Exception):
+            with patch('builtins.open', new_callable=mock_open()):
+                ParamFileManager.read('some/name.yaml')
+
+    @patch('yaml.safe_load')
+    def test_that_no_data_returns_empty_default_data(self, mock_yaml_load):
+        # Fixture
+        mock_yaml_load.return_value = self.data
+
+        # Test
+        with patch('builtins.open', new_callable=mock_open()):
+            actual_params = ParamFileManager.read('some/name.yaml')
+        
+        # Assert
+        self.assertEqual(0, len(actual_params))
+    
+    @patch('yaml.dump')
+    def test_file_end_to_end_write_read(self, mock_yaml_dump):
+        # Fixture
+        fixture_file = 'test/localization/fixtures/parameters.yaml'
+
+        file = open(fixture_file, 'r')
+        expected = yaml.safe_load(file)
+        file.close()
+
+        # Test
+        params = ParamFileManager.read(fixture_file)
+        with patch('builtins.open', new_callable=mock_open()):
+            ParamFileManager.write('some/name.yaml', params=params)
+
+            # Assert
+            mock_yaml_dump.assert_called_with(expected, ANY)
+    
+    @patch('yaml.dump')
+    def test_file_write_to_correct_file(self, mock_yaml_dump):
+        # Fixture
+        file_name = 'some/name.yaml'
+
+        # Test
+        with patch('builtins.open', new_callable=mock_open()) as mock_file:
+            ParamFileManager.write(file_name)
+
+            # Assert
+            mock_file.assert_called_with(file_name, 'w')


### PR DESCRIPTION
This pull request introduces the `ParamFileManager` class, which is responsible for reading and writing parameter configurations from a file. This functionality is helpful for persisting parameter states across different sessions, allowing users to save, load and share parameter configurations as needed.

Key changes include:

1. **New `ParamFileManager` class**: This class provides static methods for reading and writing parameter configurations to a file. It uses the YAML format for file storage, providing human-readable files and supporting complex data structures.

2. **Support for `PersistentParamState` objects**: The `write` method of `ParamFileManager` supports `PersistentParamState` objects. It extracts the `is_stored`, `default_value`, and `stored_value` attributes of these objects and writes them to the file.

3. **Robust file reading**: The `read` method of `ParamFileManager` includes checks for file type and version, raising exceptions if these fields are missing or unsupported. It also includes error handling for YAML parsing errors.

This implementation provides a solid foundation for parameter file management. Future work may include extending support to other parameter types, improving error handling, and integrating this functionality into the broader system.