### PR TITLE
cloader.read_flash is unreliable

### DIFF
--- a/cflib/bootloader/cloader.py
+++ b/cflib/bootloader/cloader.py
@@ -281,7 +281,7 @@ class Cloader:
             pk = None
             retry_counter = 5
             while ((not pk or pk.header != 0xFF or
-                    struct.unpack('<BB', pk.data[0:2]) != (addr, 0x1C)) and
+                    struct.unpack('<BBHH', pk.data[0:6]) != (addr, 0x1C, page, (i * 25))) and
                     retry_counter >= 0):
                 pk = CRTPPacket()
                 pk.set_header(0xFF, 0xFF)


### PR DESCRIPTION
When I tried to make a function that verified flash, it worked only 50% to have a correct page readout. Because the code only checks if the response is from the correct add, but not the correct part, it confuses the packets and add garbage in between.

change sponsored by stagebees.com