### PR TITLE
Improved HL commander - spiral & linear segment

### DIFF
--- a/cflib/crazyflie/high_level_commander.py
+++ b/cflib/crazyflie/high_level_commander.py
@@ -46,6 +46,8 @@ class HighLevelCommander():
     COMMAND_DEFINE_TRAJECTORY = 6
     COMMAND_TAKEOFF_2 = 7
     COMMAND_LAND_2 = 8
+    COMMAND_SPIRAL = 11
+    COMMAND_GO_TO_2 = 12
 
     ALL_GROUPS = 0
 
@@ -150,6 +152,53 @@ class HighLevelCommander():
                                       relative,
                                       x, y, z,
                                       yaw,
+                                      duration_s))
+        
+    def go_to2(self, x, y, z, yaw, duration_s, relative=False, linear=False,
+              group_mask=ALL_GROUPS):
+        """
+        Go to an absolute or relative position
+
+        :param x: X (m)
+        :param y: Y (m)
+        :param z: Z (m)
+        :param yaw: Yaw (radians)
+        :param duration_s: Time it should take to reach the position (s)
+        :param relative: True if x, y, z is relative to the current position
+        :param linear: True to use linear interpolation instead of a smooth polynomial
+        :param group_mask: Mask for which CFs this should apply to
+        """
+        self._send_packet(struct.pack('<BBBBfffff',
+                                      self.COMMAND_GO_TO_2,
+                                      group_mask,
+                                      relative,
+                                      linear,
+                                      x, y, z,
+                                      yaw,
+                                      duration_s))
+        
+    def spiral(self, angle, r0, rF, ascent, duration_s, sideways=False, clockwise=False,
+              group_mask=ALL_GROUPS):
+        """
+        Follow a spiral-like segment (spline approximation of a spiral/arc for <= 90-degree segments)
+
+        :param angle: spiral angle (rad)
+        :param r0: initial radius (m)
+        :param rF: final radius (m)
+        :param ascent: altitude gain (m)
+        :param duration_s: time it should take to reach the end of the spiral (s)
+        :param sideways: true if crazyflie should spiral sideways instead of forward
+        :param clockwise: true if crazyflie should spiral clockwise instead of counter-clockwise
+        :param group_mask: Mask for which CFs this should apply to
+        """
+        self._send_packet(struct.pack('<BBBBfffff',
+                                      self.COMMAND_SPIRAL,
+                                      group_mask,
+                                      sideways,
+                                      clockwise,
+                                      angle,
+                                      r0, rF,
+                                      ascent,
                                       duration_s))
 
     def start_trajectory(self, trajectory_id, time_scale=1.0, relative=False,

--- a/cflib/crazyflie/high_level_commander.py
+++ b/cflib/crazyflie/high_level_commander.py
@@ -41,13 +41,12 @@ class HighLevelCommander():
 
     COMMAND_SET_GROUP_MASK = 0
     COMMAND_STOP = 3
+    COMMAND_GO_TO = 4
     COMMAND_START_TRAJECTORY = 5
     COMMAND_DEFINE_TRAJECTORY = 6
     COMMAND_TAKEOFF_2 = 7
     COMMAND_LAND_2 = 8
-    COMMAND_SPIRAL = 11
-    COMMAND_GO_TO_2 = 12
-    
+
     ALL_GROUPS = 0
 
     TRAJECTORY_LOCATION_MEM = 1
@@ -132,7 +131,7 @@ class HighLevelCommander():
                                       self.COMMAND_STOP,
                                       group_mask))
 
-    def go_to(self, x, y, z, yaw, duration_s, relative=False, linear=False,
+    def go_to(self, x, y, z, yaw, duration_s, relative=False,
               group_mask=ALL_GROUPS):
         """
         Go to an absolute or relative position
@@ -143,40 +142,14 @@ class HighLevelCommander():
         :param yaw: Yaw (radians)
         :param duration_s: Time it should take to reach the position (s)
         :param relative: True if x, y, z is relative to the current position
-        :param linear: True to use linear interpolation instead of a smooth polynomial
         :param group_mask: Mask for which CFs this should apply to
         """
-        self._send_packet(struct.pack('<BBBBfffff',
-                                      self.COMMAND_GO_TO_2,
+        self._send_packet(struct.pack('<BBBfffff',
+                                      self.COMMAND_GO_TO,
                                       group_mask,
                                       relative,
-                                      linear,
                                       x, y, z,
                                       yaw,
-                                      duration_s))
-        
-    def spiral(self, angle, r0, rF, ascent, duration_s, sideways=False, clockwise=False,
-              group_mask=ALL_GROUPS):
-        """
-        Follow a spiral-like segment (spline approximation of a spiral/arc for <= 90-degree segments)
-
-        :param angle: spiral angle (rad)
-        :param r0: initial radius (m)
-        :param rF: final radius (m)
-        :param ascent: altitude gain (m)
-        :param duration_s: time it should take to reach the end of the spiral (s)
-        :param sideways: true if crazyflie should spiral sideways instead of forward
-        :param clockwise: true if crazyflie should spiral clockwise instead of counter-clockwise
-        :param group_mask: Mask for which CFs this should apply to
-        """
-        self._send_packet(struct.pack('<BBBBfffff',
-                                      self.COMMAND_SPIRAL,
-                                      group_mask,
-                                      sideways,
-                                      clockwise,
-                                      angle,
-                                      r0, rF,
-                                      ascent,
                                       duration_s))
 
     def start_trajectory(self, trajectory_id, time_scale=1.0, relative=False,

--- a/cflib/crazyflie/high_level_commander.py
+++ b/cflib/crazyflie/high_level_commander.py
@@ -150,7 +150,7 @@ class HighLevelCommander():
         """
         if self._cf.platform.get_protocol_version() < 8:
             if linear:
-                print('Warning: Linear mode is not supported in protocol version < 8, update the firmware of your crazyflie')
+                print('Warning: Linear mode not supported in protocol version < 8, update your crazyflie\'s firmware')
             self._send_packet(struct.pack('<BBBfffff',
                                           self.COMMAND_GO_TO,
                                           group_mask,
@@ -183,29 +183,29 @@ class HighLevelCommander():
         :param group_mask: Mask for which CFs this should apply to
         """
         if self._cf.platform.get_protocol_version() < 8:
-            print('Warning: Spiral command is not supported in protocol version < 8, update the firmware of your crazyflie')
+            print('Warning: Spiral command is not supported in protocol version < 8, update your crazyflie\'s firmware')
         else:
-          if angle > 2*math.pi:
-              angle = 2*math.pi
-              print('Warning: Spiral angle saturated at 2pi as it was too large')
-          elif angle < -2*math.pi:
-              angle = -2*math.pi
-              print('Warning: Spiral angle saturated at -2pi as it was too small')
-          if r0 < 0:
-              r0 = 0
-              print('Warning: Initial radius set to 0 as it cannot be negative')
-          if rF < 0:
-              rF = 0
-              print('Warning: Final radius set to 0 as it cannot be negative')
-          self._send_packet(struct.pack('<BBBBfffff',
-                                        self.COMMAND_SPIRAL,
-                                        group_mask,
-                                        sideways,
-                                        clockwise,
-                                        angle,
-                                        r0, rF,
-                                        ascent,
-                                        duration_s))
+            if angle > 2*math.pi:
+                angle = 2*math.pi
+                print('Warning: Spiral angle saturated at 2pi as it was too large')
+            elif angle < -2*math.pi:
+                angle = -2*math.pi
+                print('Warning: Spiral angle saturated at -2pi as it was too small')
+            if r0 < 0:
+                r0 = 0
+                print('Warning: Initial radius set to 0 as it cannot be negative')
+            if rF < 0:
+                rF = 0
+                print('Warning: Final radius set to 0 as it cannot be negative')
+            self._send_packet(struct.pack('<BBBBfffff',
+                                          self.COMMAND_SPIRAL,
+                                          group_mask,
+                                          sideways,
+                                          clockwise,
+                                          angle,
+                                          r0, rF,
+                                          ascent,
+                                          duration_s))
 
     def start_trajectory(self, trajectory_id, time_scale=1.0, relative=False,
                          reversed=False, group_mask=ALL_GROUPS):

--- a/cflib/crazyflie/high_level_commander.py
+++ b/cflib/crazyflie/high_level_commander.py
@@ -27,7 +27,6 @@ Used for sending high level setpoints to the Crazyflie
 """
 import math
 import struct
-import warnings
 
 from cflib.crtp.crtpstack import CRTPPacket
 from cflib.crtp.crtpstack import CRTPPort
@@ -151,8 +150,8 @@ class HighLevelCommander():
         """
         if self._cf.platform.get_protocol_version() < 8:
             if linear:
-                warnings.warning('Linear mode is not supported in protocol version < 8, update your Crazyflie firmware')
-            self._send_packet(struct.pack('<BBBBfffff',
+                print('Warning: Linear mode is not supported in protocol version < 8, update the firmware of your crazyflie')
+            self._send_packet(struct.pack('<BBBfffff',
                                           self.COMMAND_GO_TO,
                                           group_mask,
                                           relative,
@@ -161,7 +160,7 @@ class HighLevelCommander():
                                           duration_s))
         else:
             self._send_packet(struct.pack('<BBBBfffff',
-                                          self.COMMAND_GO_TO2,
+                                          self.COMMAND_GO_TO_2,
                                           group_mask,
                                           relative,
                                           linear,
@@ -183,27 +182,30 @@ class HighLevelCommander():
         :param clockwise: true if crazyflie should spiral clockwise instead of counter-clockwise
         :param group_mask: Mask for which CFs this should apply to
         """
-        if angle > 2*math.pi:
-            angle = 2*math.pi
-            warnings.warning('Spiral angle saturated at 2pi as it was too large')
-        elif angle < -2*math.pi:
-            angle = -2*math.pi
-            warnings.warning('Spiral angle saturated at -2pi as it was too small')
-        if r0 < 0:
-            r0 = 0
-            warnings.warning('Initial radius set to 0 as it cannot be negative')
-        if rF < 0:
-            rF = 0
-            warnings.warning('Final radius set to 0 as it cannot be negative')
-        self._send_packet(struct.pack('<BBBBfffff',
-                                      self.COMMAND_SPIRAL,
-                                      group_mask,
-                                      sideways,
-                                      clockwise,
-                                      angle,
-                                      r0, rF,
-                                      ascent,
-                                      duration_s))
+        if self._cf.platform.get_protocol_version() < 8:
+            print('Warning: Spiral command is not supported in protocol version < 8, update the firmware of your crazyflie')
+        else:
+          if angle > 2*math.pi:
+              angle = 2*math.pi
+              print('Warning: Spiral angle saturated at 2pi as it was too large')
+          elif angle < -2*math.pi:
+              angle = -2*math.pi
+              print('Warning: Spiral angle saturated at -2pi as it was too small')
+          if r0 < 0:
+              r0 = 0
+              print('Warning: Initial radius set to 0 as it cannot be negative')
+          if rF < 0:
+              rF = 0
+              print('Warning: Final radius set to 0 as it cannot be negative')
+          self._send_packet(struct.pack('<BBBBfffff',
+                                        self.COMMAND_SPIRAL,
+                                        group_mask,
+                                        sideways,
+                                        clockwise,
+                                        angle,
+                                        r0, rF,
+                                        ascent,
+                                        duration_s))
 
     def start_trajectory(self, trajectory_id, time_scale=1.0, relative=False,
                          reversed=False, group_mask=ALL_GROUPS):

--- a/cflib/crazyflie/high_level_commander.py
+++ b/cflib/crazyflie/high_level_commander.py
@@ -153,9 +153,9 @@ class HighLevelCommander():
                                       x, y, z,
                                       yaw,
                                       duration_s))
-        
+
     def go_to2(self, x, y, z, yaw, duration_s, relative=False, linear=False,
-              group_mask=ALL_GROUPS):
+               group_mask=ALL_GROUPS):
         """
         Go to an absolute or relative position
 
@@ -176,9 +176,9 @@ class HighLevelCommander():
                                       x, y, z,
                                       yaw,
                                       duration_s))
-        
+
     def spiral(self, angle, r0, rF, ascent, duration_s, sideways=False, clockwise=False,
-              group_mask=ALL_GROUPS):
+               group_mask=ALL_GROUPS):
         """
         Follow a spiral-like segment (spline approximation of a spiral/arc for <= 90-degree segments)
 

--- a/cflib/crazyflie/high_level_commander.py
+++ b/cflib/crazyflie/high_level_commander.py
@@ -41,12 +41,13 @@ class HighLevelCommander():
 
     COMMAND_SET_GROUP_MASK = 0
     COMMAND_STOP = 3
-    COMMAND_GO_TO = 4
     COMMAND_START_TRAJECTORY = 5
     COMMAND_DEFINE_TRAJECTORY = 6
     COMMAND_TAKEOFF_2 = 7
     COMMAND_LAND_2 = 8
-
+    COMMAND_SPIRAL = 11
+    COMMAND_GO_TO_2 = 12
+    
     ALL_GROUPS = 0
 
     TRAJECTORY_LOCATION_MEM = 1
@@ -131,7 +132,7 @@ class HighLevelCommander():
                                       self.COMMAND_STOP,
                                       group_mask))
 
-    def go_to(self, x, y, z, yaw, duration_s, relative=False,
+    def go_to(self, x, y, z, yaw, duration_s, relative=False, linear=False,
               group_mask=ALL_GROUPS):
         """
         Go to an absolute or relative position
@@ -142,14 +143,40 @@ class HighLevelCommander():
         :param yaw: Yaw (radians)
         :param duration_s: Time it should take to reach the position (s)
         :param relative: True if x, y, z is relative to the current position
+        :param linear: True to use linear interpolation instead of a smooth polynomial
         :param group_mask: Mask for which CFs this should apply to
         """
-        self._send_packet(struct.pack('<BBBfffff',
-                                      self.COMMAND_GO_TO,
+        self._send_packet(struct.pack('<BBBBfffff',
+                                      self.COMMAND_GO_TO_2,
                                       group_mask,
                                       relative,
+                                      linear,
                                       x, y, z,
                                       yaw,
+                                      duration_s))
+        
+    def spiral(self, angle, r0, rF, ascent, duration_s, sideways=False, clockwise=False,
+              group_mask=ALL_GROUPS):
+        """
+        Follow a spiral-like segment (spline approximation of a spiral/arc for <= 90-degree segments)
+
+        :param angle: spiral angle (rad)
+        :param r0: initial radius (m)
+        :param rF: final radius (m)
+        :param ascent: altitude gain (m)
+        :param duration_s: time it should take to reach the end of the spiral (s)
+        :param sideways: true if crazyflie should spiral sideways instead of forward
+        :param clockwise: true if crazyflie should spiral clockwise instead of counter-clockwise
+        :param group_mask: Mask for which CFs this should apply to
+        """
+        self._send_packet(struct.pack('<BBBBfffff',
+                                      self.COMMAND_SPIRAL,
+                                      group_mask,
+                                      sideways,
+                                      clockwise,
+                                      angle,
+                                      r0, rF,
+                                      ascent,
                                       duration_s))
 
     def start_trajectory(self, trajectory_id, time_scale=1.0, relative=False,


### PR DESCRIPTION
This PR extends the functionality of the HL commander by adding 1) a linear option to the GOTO command and 2) a spiral command.
More details in the corresponding firmware PR: https://github.com/bitcraze/crazyflie-firmware/pull/1410