### PR TITLE
Introduce Link Statistics and Latency Measurement

### DIFF
--- a/cflib/crazyflie/link_statistics.py
+++ b/cflib/crazyflie/link_statistics.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+#
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2024 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, in version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+This module provides tools for tracking statistics related to the communication
+link between the Crazyflie and the lib. Currently, it focuses on tracking latency
+but is designed to be extended with additional link statistics in the future.
+"""
+
+from cflib.crtp.crtpstack import CRTPPort, CRTPPacket
+from threading import Thread, Event
+import time
+import struct
+import numpy as np
+
+__author__ = "Bitcraze AB"
+__all__ = ["LinkStatistics"]
+
+PING_HEADER = 0x0
+ECHO_CHANNEL = 0
+
+
+class LinkStatistics:
+    """
+    LinkStatistics class manages the collection of various statistics related to the
+    communication link between the Crazyflie and the lib.
+
+    This class serves as a high-level manager, initializing and coordinating multiple
+    statistics trackers, such as Latency. It allows starting and stopping all
+    statistics trackers simultaneously. Future statistics can be added to extend
+    the class's functionality.
+
+    Attributes:
+        _cf (Crazyflie): A reference to the Crazyflie instance.
+        latency (Latency): An instance of the Latency class that tracks latency statistics.
+    """
+
+    def __init__(self, crazyflie):
+        self._cf = crazyflie
+
+        self.latency = Latency(self._cf)
+
+    def start(self):
+        """
+        Start collecting all statistics.
+        """
+        self.latency.start()
+
+    def stop(self):
+        """
+        Stop collecting all statistics.
+        """
+        self.latency.stop()
+
+
+class Latency:
+    """
+    The Latency class measures and tracks the latency of the communication link
+    between the Crazyflie and the lib.
+
+    This class periodically sends ping requests to the Crazyflie and tracks
+    the round-trip time (latency). It calculates and stores the 95th percentile
+    latency over a rolling window of recent latency measurements.
+
+    Attributes:
+        _cf (Crazyflie): A reference to the Crazyflie instance.
+        latency (float): The current calculated 95th percentile latency in milliseconds.
+        _stop_event (Event): An event object to control the stopping of the ping thread.
+        _ping_thread_instance (Thread): Thread instance for sending ping requests at intervals.
+    """
+
+    def __init__(self, crazyflie):
+        self._cf = crazyflie
+        self._cf.add_header_callback(self._ping_response, CRTPPort.LINKCTRL, 0)
+        self._stop_event = Event()
+        self._ping_thread_instance = Thread(target=self._ping_thread)
+        self.latency = 0
+
+    def start(self):
+        """
+        Start the latency tracking process.
+
+        This method initiates a background thread that sends ping requests
+        at regular intervals to measure and track latency statistics.
+        """
+        self._ping_thread_instance.start()
+
+    def stop(self):
+        """
+        Stop the latency tracking process.
+
+        This method stops the background thread and ceases sending further
+        ping requests, halting latency measurement.
+        """
+        self._stop_event.set()
+        self._ping_thread_instance.join()
+
+    def _ping_thread(self, interval: float = 1.0) -> None:
+        """
+        Background thread method that sends a ping to the Crazyflie at regular intervals.
+
+        This method runs in a separate thread and continues to send ping requests
+        until the stop event is set.
+
+        Args:
+            interval (float): The time (in seconds) to wait between ping requests. Default is 1 second.
+        """
+        while not self._stop_event.is_set():
+            self.ping()
+            time.sleep(interval)
+
+    def ping(self) -> None:
+        """
+        Send a ping request to the Crazyflie to measure latency.
+
+        A ping packet is sent to the Crazyflie with the current timestamp and a
+        header identifier to differentiate it from other echo responses. The latency
+        is calculated upon receiving the response.
+        """
+        ping_packet = CRTPPacket()
+        ping_packet.set_header(CRTPPort.LINKCTRL, ECHO_CHANNEL)
+
+        # Pack the current time as the ping timestamp
+        current_time = time.time()
+        ping_packet.data = struct.pack("<Bd", PING_HEADER, current_time)
+        self._cf.send_packet(ping_packet)
+
+    def _ping_response(self, packet):
+        """
+        Callback method for processing the echo response received from the Crazyflie.
+
+        This method is called when a ping response is received. It checks the header
+        to verify that it matches the sent ping header before calculating the latency
+        based on the timestamp included in the ping request.
+
+        Args:
+            packet (CRTPPacket): The packet received from the Crazyflie containing
+            the echo response data.
+        """
+        received_header, received_timestamp = struct.unpack("<Bd", packet.data)
+        if received_header != PING_HEADER:
+            return
+        self.latency = self._calculate_p95_latency(received_timestamp)
+
+    def _calculate_p95_latency(self, timestamp):
+        """
+        Calculate the 95th percentile latency based on recent ping measurements.
+
+        This method records the round-trip time for a ping response and maintains
+        a rolling window of latency values to compute the 95th percentile.
+
+        Args:
+            timestamp (float): The timestamp from the sent ping packet to calculate
+            the round-trip time.
+
+        Returns:
+            float: The updated 95th percentile latency in milliseconds.
+        """
+        if not hasattr(self, "_latencies"):
+            self._latencies = []
+
+        instantaneous_latency = (time.time() - timestamp) * 1000
+        self._latencies.append(instantaneous_latency)
+        if len(self._latencies) > 100:
+            self._latencies.pop(0)
+        p95_latency = np.percentile(self._latencies, 95)
+        return p95_latency

--- a/cflib/crtp/radiodriver.py
+++ b/cflib/crtp/radiodriver.py
@@ -49,8 +49,6 @@ from typing import Tuple
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
 
-import numpy as np
-
 import cflib.drivers.crazyradio as crazyradio
 from .crtpstack import CRTPPacket
 from .exceptions import WrongUriType
@@ -566,6 +564,7 @@ class _RadioDriverThread(threading.Thread):
             self._curr_down = 1 - self._curr_down
         if resp and resp.ack:
             self._curr_up = 1 - self._curr_up
+
         return resp
 
     def run(self):
@@ -653,12 +652,10 @@ class _RadioDriverThread(threading.Thread):
 
             # get the next packet to send of relaxation (wait 10ms)
             outPacket = None
-            
-            if not outPacket:
-                try:
-                    outPacket = self._out_queue.get(True, waitTime)
-                except queue.Empty:
-                    outPacket = None
+            try:
+                outPacket = self._out_queue.get(True, waitTime)
+            except queue.Empty:
+                outPacket = None
 
             dataOut = array.array('B')
 

--- a/cflib/crtp/radiodriver.py
+++ b/cflib/crtp/radiodriver.py
@@ -49,8 +49,10 @@ from typing import Tuple
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
 
+import numpy as np
+
 import cflib.drivers.crazyradio as crazyradio
-from .crtpstack import CRTPPacket
+from .crtpstack import CRTPPacket, CRTPPort
 from .exceptions import WrongUriType
 from cflib.crtp.crtpdriver import CRTPDriver
 from cflib.drivers.crazyradio import Crazyradio
@@ -534,6 +536,12 @@ class _RadioDriverThread(threading.Thread):
         self._retry_sum = 0
         self.rate_limit = rate_limit
 
+        self._packed_last_ping_time = None
+        self._last_ping_time = 0
+        self._latencies = []
+        self._p95_latency = None
+        self._ping_timeout = 3
+
         self._curr_up = 0
         self._curr_down = 1
 
@@ -632,8 +640,12 @@ class _RadioDriverThread(threading.Thread):
             # If there is a copter in range, the packet is analysed and the
             # next packet to send is prepared
             if (len(data) > 0):
-                inPacket = CRTPPacket(data[0], list(data[1:]))
-                self._in_queue.put(inPacket)
+                if data[1:] == self._packed_last_ping_time:
+                    # This is a ping response
+                    self._calculate_latency(struct.unpack("<d", data[1:])[0])
+                else:
+                    inPacket = CRTPPacket(data[0], list(data[1:]))
+                    self._in_queue.put(inPacket)
                 waitTime = 0
                 emptyCtr = 0
             else:
@@ -651,11 +663,13 @@ class _RadioDriverThread(threading.Thread):
                 waitTime = 0
 
             # get the next packet to send of relaxation (wait 10ms)
-            outPacket = None
-            try:
-                outPacket = self._out_queue.get(True, waitTime)
-            except queue.Empty:
-                outPacket = None
+            outPacket = self._handle_ping()
+            
+            if not outPacket:
+                try:
+                    outPacket = self._out_queue.get(True, waitTime)
+                except queue.Empty:
+                    outPacket = None
 
             dataOut = array.array('B')
 
@@ -669,6 +683,43 @@ class _RadioDriverThread(threading.Thread):
             else:
                 dataOut.append(0xFF)
 
+    def _handle_ping(self):
+        # Initialize the ping counter if it doesn't exist yet
+        if not hasattr(self, '_ping_counter'):
+            self._ping_counter = 0
+
+        self._ping_counter += 1
+
+        # Send a ping every 1000 packets or if the last ping timed out
+        if (self._ping_counter % 1000 == 0 and self._packed_last_ping_time is None) or (
+            self._last_ping_time and time.time() - self._last_ping_time > self._ping_timeout):
+            out_packet = CRTPPacket()
+            out_packet.set_header(CRTPPort.LINKCTRL, 0)
+
+            # Pack the current time as the ping timestamp
+            current_time = time.time()
+            out_packet.data = struct.pack("<d", *[current_time])
+
+            self._packed_last_ping_time = out_packet.data
+            self._last_ping_time = current_time
+
+            # Reset the counter after a ping is sent
+            self._ping_counter = 0
+
+            return out_packet
+            
+        return None
+    
+    def _calculate_latency(self, timestamp):
+        latency = (time.time() - timestamp) * 1000
+        self._latencies.append(latency)
+        if len(self._latencies) > 100:
+            self._latencies.pop(0)
+        self._p95_latency = np.percentile(self._latencies, 95)
+        print("95th percentile latency: {} ms".format(self._p95_latency))
+
+        # Indicate that the next ping can be sent
+        self._packed_last_ping_time = None
 
 def set_retries_before_disconnect(nr_of_retries):
     global _nr_of_retries


### PR DESCRIPTION
This PR introduces a framework for link statistics, enabling the tracking of various metrics, starting with latency measurement.

* LinkStatistics Class: A new class to manage multiple types of link statistics, facilitating the addition of more metrics in the future.
* Latency Measurement: A dedicated Latency class is introduced to send periodic ping requests to the Crazyflie. It calculates the round-trip latency and maintains the 95th percentile (p95) latency over recent measurements.

The implementation improves the lib's ability to monitor communication quality and lays the groundwork for further enhancements in link statistics.