### PR TITLE
Bandwidth congestion and rate from radio driver

### DIFF
--- a/cflib/crazyflie/__init__.py
+++ b/cflib/crazyflie/__init__.py
@@ -208,6 +208,11 @@ class Crazyflie():
         """Called from link driver to report link quality"""
         self.link_quality_updated.call(percentage)
 
+    def _link_congestion_cb(self, congestion_up, congestion_down):
+        """Called from link driver to report link congestion"""
+        logger.info('Link congestion: up=%f down=%f', congestion_up,
+                     congestion_down)
+
     def _check_for_initial_packet_cb(self, data):
         """
         Called when first packet arrives from Crazyflie.
@@ -229,7 +234,7 @@ class Crazyflie():
         self.link_uri = link_uri
         try:
             self.link = cflib.crtp.get_link_driver(
-                link_uri, self._link_quality_cb, self._link_error_cb)
+                link_uri, self._link_quality_cb, self._link_error_cb, self._link_congestion_cb)
 
             if not self.link:
                 message = 'No driver found or malformed URI: {}' \

--- a/cflib/crazyflie/__init__.py
+++ b/cflib/crazyflie/__init__.py
@@ -99,6 +99,7 @@ class Crazyflie():
         self.packet_sent = Caller()
         # Called when the link driver updates the link quality measurement
         self.link_quality_updated = Caller()
+        self.link_quality_low_level_updated = Caller()
 
         self.state = State.DISCONNECTED
 
@@ -208,10 +209,11 @@ class Crazyflie():
         """Called from link driver to report link quality"""
         self.link_quality_updated.call(percentage)
 
-    def _link_congestion_cb(self, congestion_up, congestion_down):
+    def _link_quality_low_level_cb(self, rate_up, rate_down, congestion_up, congestion_down):
         """Called from link driver to report link congestion"""
-        logger.info('Link congestion: up=%f down=%f', congestion_up,
-                     congestion_down)
+        #logger.info('Rate congestion: up=%d pk/sec down=%d pk/sec', rate_up, rate_down)
+        #logger.info('Link congestion: up=%f perc down=%f perc', congestion_up, congestion_down)
+        self.link_quality_low_level_updated.call(int(rate_up), int(rate_down), congestion_up, congestion_down)
 
     def _check_for_initial_packet_cb(self, data):
         """
@@ -234,7 +236,7 @@ class Crazyflie():
         self.link_uri = link_uri
         try:
             self.link = cflib.crtp.get_link_driver(
-                link_uri, self._link_quality_cb, self._link_error_cb, self._link_congestion_cb)
+                link_uri, self._link_quality_cb, self._link_error_cb, self._link_quality_low_level_cb)
 
             if not self.link:
                 message = 'No driver found or malformed URI: {}' \

--- a/cflib/crtp/__init__.py
+++ b/cflib/crtp/__init__.py
@@ -89,7 +89,7 @@ def get_interfaces_status():
     return status
 
 
-def get_link_driver(uri, link_quality_callback=None, link_error_callback=None, link_congestion_callback=None):
+def get_link_driver(uri, link_quality_callback=None, link_error_callback=None, link_quality_low_level_callback=None):
     """Return the link driver for the given URI. Returns None if no driver
     was found for the URI or the URI was not well formatted for the matching
     driver."""
@@ -97,7 +97,7 @@ def get_link_driver(uri, link_quality_callback=None, link_error_callback=None, l
         try:
             instance = driverClass()
             if isinstance(instance,RadioDriver):
-                instance.connect(uri, link_quality_callback, link_error_callback, link_congestion_callback)
+                instance.connect(uri, link_quality_callback, link_error_callback, link_quality_low_level_callback)
             else:
                 instance.connect(uri, link_quality_callback, link_error_callback)
             return instance

--- a/cflib/crtp/__init__.py
+++ b/cflib/crtp/__init__.py
@@ -89,14 +89,17 @@ def get_interfaces_status():
     return status
 
 
-def get_link_driver(uri, link_quality_callback=None, link_error_callback=None):
+def get_link_driver(uri, link_quality_callback=None, link_error_callback=None, link_congestion_callback=None):
     """Return the link driver for the given URI. Returns None if no driver
     was found for the URI or the URI was not well formatted for the matching
     driver."""
     for driverClass in CLASSES:
         try:
             instance = driverClass()
-            instance.connect(uri, link_quality_callback, link_error_callback)
+            if isinstance(instance,RadioDriver):
+                instance.connect(uri, link_quality_callback, link_error_callback, link_congestion_callback)
+            else:
+                instance.connect(uri, link_quality_callback, link_error_callback)
             return instance
         except WrongUriType:
             continue


### PR DESCRIPTION
Just an example of how the congestion of the bandwidth can be calculated per null packet, along with the rate of the up and down link.

Not sure if this should actually be a call back of the crazyflie instance itself, since it is a statistic that is more linked to the crazyradio hardware as it looks at all the packets send. But the original link_quality was implemented like this though. 

This is connected to  #469 