### PR TITLE
Add callback for handling link errors in disconnected state

### DIFF
--- a/cflib/crazyflie/__init__.py
+++ b/cflib/crazyflie/__init__.py
@@ -93,6 +93,8 @@ class Crazyflie():
 
         # Called if establishing of the link fails (i.e times out)
         self.connection_failed = Caller()
+        # Called if link driver has an error while state is DISCONNECTED
+        self.disconnected_link_error = Caller()
         # Called for every packet received
         self.packet_received = Caller()
         # Called for every packet sent
@@ -198,10 +200,12 @@ class Crazyflie():
         self.link = None
         if (self.state == State.INITIALIZED):
             self.connection_failed.call(self.link_uri, errmsg)
-        if (self.state == State.CONNECTED or
+        elif (self.state == State.CONNECTED or
                 self.state == State.SETUP_FINISHED):
             self.disconnected.call(self.link_uri)
             self.connection_lost.call(self.link_uri, errmsg)
+        elif (self.state == State.DISCONNECTED):
+            self.disconnected_link_error.call(self.link_uri, errmsg)
         self.state = State.DISCONNECTED
 
     def _link_quality_cb(self, percentage):


### PR DESCRIPTION
Previously, there was no way to hook into link errors when the state was disconnected. 

For example, when somehow unable to connect to a CF (let's say because it was turned off); on the initial connection attempt, a callback would be triggered for a failed connection, allowing scripts to handle the error. However, subsequent attempts did not trigger any callback, forcing autonomous scripts to blindly retry with a timeout. This commit introduces a `disconnected_link_error` callback, enabling scripts to respond to link errors more effectively and retry connections programmatically.