### PR TITLE
Bump required Python version

### DIFF
--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -34,10 +34,10 @@ jobs:
       - name: install lib
         run: pip install -e .
 
-  minimum-python37:
+  minimum-python310:
     runs-on: ubuntu-latest
     container:
-      image: python:3.7
+      image: python:3.10
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -6,19 +6,19 @@ on:
   - cron:  '0 2 * * *'
 
 jobs:
-#  python-latest:
-#    runs-on: ubuntu-latest
-#    container:
-#      image: python:latest
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: python version
-#        run: python --version
-#
-#      - name: install lib
-#        run: pip install -e .
+  python-latest:
+    runs-on: ubuntu-latest
+    container:
+      image: python:latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: python version
+        run: python --version
+
+      - name: install lib
+        run: pip install -e .
 
   python-python311:
     runs-on: ubuntu-latest

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -5,7 +5,7 @@ page_id: install
 
 ## Requirements
 
-This project requires Python 3.8 - 3.12.
+This project requires Python 3.10+.
 
 
 See below sections for more platform-specific requirements.


### PR DESCRIPTION
- Bump required Python version to 3.10
- Re-enable latest Python dependency check. Works in Python 3.13, yet slow: https://github.com/bitcraze/crazyflie-lib-python/actions/runs/11362341966