### PR TITLE
Dependency update, Py313 doc, and automatic versioning

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,6 +26,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test-python-publish.yml
+++ b/.github/workflows/test-python-publish.yml
@@ -26,6 +26,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -7,6 +7,7 @@ page_id: install
 
 This project requires Python 3.10+.
 
+To install on Python 3.13, build tools and Python development headers are required.
 
 See below sections for more platform-specific requirements.
 ## Install from Source
@@ -77,6 +78,8 @@ With linux, the crazyradio is easily recognized, but you have to setup UDEVpermi
 ### Windows
 
 Look at the [Zadig crazyradio instructions](https://www.bitcraze.io/documentation/repository/crazyradio-firmware/master/building/usbwindows/) to install crazyradio on Windows
+
+If you're using Python 3.13, you need to install [Visual Studio](https://visualstudio.microsoft.com/downloads/). During the installation process, you only need to select the Desktop Development with C++ workload in the Visual Studio Installer.
 
 ### macOS
 If you are using python 3.12 on mac you need to install libusb using homebrew.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,16 @@ license = { text = "GPLv3" }
 keywords = ["driver", "crazyflie", "quadcopter"]
 
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Topic :: System :: Hardware :: Hardware Drivers",
+    "Topic :: Scientific/Engineering :: Robotics",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Education",
+    "Intended Audience :: Developers",
+    "Operating System :: Linux",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
 
     # Supported Python versions
     "Programming Language :: Python :: 3.10",
@@ -28,13 +35,12 @@ classifiers = [
 requires-python = ">= 3.10"
 
 dependencies = [
-    "pyusb>=1.0.0b2",
+    "pyusb~=1.2",
     "libusb-package~=1.0",
-    "scipy~=1.7",
-    "numpy~=1.20",
-    "packaging~=24.0",
+    "scipy~=1.14",
+    "numpy~=1.26",
+    "packaging~=24.2",
 ]
-
 
 [project.urls]
 Homepage = "https://www.bitcraze.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=61.0", "wheel", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "cflib"
-version = "0.1.27.1.dev0"
+dynamic = ["version"]
 description = "Crazyflie Python driver"
 authors = [
     { name = "Bitcraze and contributors", email = "contact@bitcraze.io" },
@@ -59,3 +59,6 @@ find = { exclude = ["examples", "test"] }
 
 [tool.setuptools.package-data]
 "cflib.resources.binaries" = ["cflib/resources/binaries/*.bin"]
+
+[tool.setuptools_scm]
+version_scheme = "no-guess-dev"


### PR DESCRIPTION
- Update dependencies (Numpy >1 breaks Vispy, so staying at 1)
- Add Python 3.13-specific install instructions (compile wheels, no Numpy 1 wheels available)
- Implement automatic versioning like in cfclient