### PR TITLE
Nightly Build: Use Visual Studio for compiling wheels on Windows 

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,6 +33,12 @@ jobs:
         $(brew --prefix)/bin/python${{ matrix.python-version }} -m venv venv
         echo "PATH=$(pwd)/venv/bin:$PATH" >> $GITHUB_ENV
 
+    - name: Set up MSVC environment (Windows)
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
+      if: runner.os == 'Windows'
+
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip build setuptools


### PR DESCRIPTION
Allows compiling wheels as intended for Windows

With fix: https://github.com/bitcraze/crazyflie-lib-python/actions/runs/11955313535/job/33327402742
Without: https://github.com/bitcraze/crazyflie-lib-python/actions/runs/11953043649/job/33321138027