### PR TITLE
Remove deprecated call to setDaemon

### DIFF
--- a/cflib/crazyflie/__init__.py
+++ b/cflib/crazyflie/__init__.py
@@ -109,7 +109,7 @@ class Crazyflie():
                                    rw_cache=rw_cache)
 
         self.incoming = _IncomingPacketHandler(self)
-        self.incoming.setDaemon(True)
+        self.incoming.daemon = True
         if self.link:
             self.incoming.start()
 

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -520,7 +520,7 @@ class _ExtendedTypeFetcher(Thread):
 
     def __init__(self, cf, toc):
         Thread.__init__(self)
-        self.setDaemon(True)
+        self.daemon = True
         self._lock = Lock()
 
         self._cf = cf
@@ -599,7 +599,7 @@ class _ParamUpdater(Thread):
     def __init__(self, cf, useV2, updated_callback):
         """Initialize the thread"""
         Thread.__init__(self)
-        self.setDaemon(True)
+        self.daemon = True
         self.wait_lock = Lock()
         self.cf = cf
         self._useV2 = useV2

--- a/cflib/crtp/radiodriver.py
+++ b/cflib/crtp/radiodriver.py
@@ -156,7 +156,7 @@ class _SharedRadio(Thread):
 
         self._lock = Semaphore(1)
 
-        self.setDaemon(True)
+        self.daemon = True
 
         self.start()
 


### PR DESCRIPTION
The ```thread.setDaemon()``` call is [deprecated since Python 3.10](https://docs.python.org/3.10/library/threading.html#threading.Thread.setDaemon).

Since we know have Python 3.10 as minimum version, this PR removes this call and replace it by setting the daemon attribute instead.