### PR TITLE
Exclude py 3.13 with mac from unittests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, lab-mac, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        exclude:
+          - os: lab-mac
+            python-version: ["3.13"]
 
     runs-on: ${{ matrix.os }}
 

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -9,6 +9,8 @@ This project requires Python 3.10+.
 
 To install on Python 3.13, build tools and Python development headers are required.
 
+***NOTE: Running with python 3.13 on macOS is not officially supported***
+
 See below sections for more platform-specific requirements.
 ## Install from Source
 ### Clone  the repository


### PR DESCRIPTION
Document this combination not supported