### PR TITLE
Fix restart method in radiodriver.py.

### DIFF
--- a/cflib/crtp/radiodriver.py
+++ b/cflib/crtp/radiodriver.py
@@ -260,6 +260,7 @@ class RadioDriver(CRTPDriver):
 
         devid, channel, datarate, address, rate_limit = self.parse_uri(uri)
         self.uri = uri
+        self.rate_limit = rate_limit
 
         if self._radio is None:
             self._radio = RadioManager.open(devid)
@@ -383,7 +384,8 @@ class RadioDriver(CRTPDriver):
                                           self.out_queue,
                                           self.link_quality_callback,
                                           self.link_error_callback,
-                                          self)
+                                          self,
+                                          self.rate_limit)
         self._thread.start()
 
     def close(self):


### PR DESCRIPTION
Restart doesn't work anymore, since _RadioDriverThread expects a rate_limit. Fixing this by saving the rate_limit and reusing it here.