### PR TITLE
Aris/Clarify_Same_Channel_In_Swarm_Examples

### DIFF
--- a/examples/swarm/hl-commander-swarm.py
+++ b/examples/swarm/hl-commander-swarm.py
@@ -82,6 +82,7 @@ uris = {
     'radio://0/30/2M/E7E7E7E711',
     'radio://0/30/2M/E7E7E7E712',
     # Add more URIs if you want more copters in the swarm
+    # URIs in a swarm using the same radio must also be on the same channel
 }
 
 if __name__ == '__main__':

--- a/examples/swarm/swarmSequence.py
+++ b/examples/swarm/swarmSequence.py
@@ -52,6 +52,7 @@ from cflib.crazyflie.swarm import CachedCfFactory
 from cflib.crazyflie.swarm import Swarm
 
 # Change uris and sequences according to your setup
+# URIs in a swarm using the same radio must also be on the same channel
 URI1 = 'radio://0/70/2M/E7E7E7E701'
 URI2 = 'radio://0/70/2M/E7E7E7E702'
 URI3 = 'radio://0/70/2M/E7E7E7E703'

--- a/examples/swarm/swarmSequenceCircle.py
+++ b/examples/swarm/swarmSequenceCircle.py
@@ -44,6 +44,7 @@ from cflib.crazyflie.swarm import CachedCfFactory
 from cflib.crazyflie.swarm import Swarm
 
 # Change uris according to your setup
+# URIs in a swarm using the same radio must also be on the same channel
 URI0 = 'radio://0/70/2M/E7E7E7E7E7'
 URI1 = 'radio://0/110/2M/E7E7E7E702'
 URI2 = 'radio://0/94/2M/E7E7E7E7E7'

--- a/examples/swarm/synchronizedSequence.py
+++ b/examples/swarm/synchronizedSequence.py
@@ -59,6 +59,7 @@ uris = [
     'radio://0/10/2M/E7E7E7E702',  # cf_id 1, startup position [ 0, 0]
     'radio://0/10/2M/E7E7E7E703',  # cf_id 3, startup position [0.5, 0.5]
     # Add more URIs if you want more copters in the swarm
+    # URIs in a swarm using the same radio must also be on the same channel
 ]
 
 sequence = [


### PR DESCRIPTION
There is this issue [here](https://github.com/bitcraze/crazyflie-lib-python/issues/485). I added an  inline comment above the listed URIs in the swarm examples.