### PR TITLE
Added warning about get_estimated_positions() usage

### DIFF
--- a/cflib/crazyflie/swarm.py
+++ b/cflib/crazyflie/swarm.py
@@ -130,6 +130,10 @@ class Swarm:
         """
         Return a `dict`, keyed by URI and with the SwarmPosition namedtuples as
         value, with the estimated (x, y, z) of each Crazyflie in the swarm.
+
+        This function is very costly in resources and is not recommended to be
+        used in a loop. To continuously get the position of the Crazyflies, use the
+        start_position_printing() function in the autonomousSequence.py example.
         """
         self.parallel_safe(self.__get_estimated_position)
         return self._positions


### PR DESCRIPTION
Based on this [Issue](https://github.com/bitcraze/crazyflie-lib-python/issues/363), the `get_estimated_positions()` function should not be used in a loop.