### PR TITLE
Send continuous zero setpoints until landing in ramp examples

### DIFF
--- a/examples/motors/multiramp.py
+++ b/examples/motors/multiramp.py
@@ -106,6 +106,9 @@ class MotorRampExample:
             # to prevent the supervisor from intervening due to missing regular setpoints
             self._cf.commander.send_setpoint(0, 0, 0, 0)
             time.sleep(0.1)
+        # Sleeping before closing the link makes sure the last
+        # packet leaves before the link is closed, since the
+        # message queue is not flushed before closing
         self._cf.close_link()
 
 

--- a/examples/motors/multiramp.py
+++ b/examples/motors/multiramp.py
@@ -101,10 +101,11 @@ class MotorRampExample:
             if thrust >= 25000:
                 thrust_mult = -1
             thrust += thrust_step * thrust_mult
-        self._cf.commander.send_setpoint(0, 0, 0, 0)
-        # Make sure that the last packet leaves before the link is closed
-        # since the message queue is not flushed before closing
-        time.sleep(0.1)
+        for _ in range(30):
+            # Continuously send the zero setpoint until the drone is recognized as landed
+            # to prevent the supervisor from intervening due to missing regular setpoints
+            self._cf.commander.send_setpoint(0, 0, 0, 0)
+            time.sleep(0.1)
         self._cf.close_link()
 
 

--- a/examples/motors/ramp.py
+++ b/examples/motors/ramp.py
@@ -104,6 +104,9 @@ class MotorRampExample:
             # to prevent the supervisor from intervening due to missing regular setpoints
             self._cf.commander.send_setpoint(0, 0, 0, 0)
             time.sleep(0.1)
+        # Sleeping before closing the link makes sure the last
+        # packet leaves before the link is closed, since the
+        # message queue is not flushed before closing
         self._cf.close_link()
 
 

--- a/examples/motors/ramp.py
+++ b/examples/motors/ramp.py
@@ -99,10 +99,11 @@ class MotorRampExample:
             if thrust >= 25000:
                 thrust_mult = -1
             thrust += thrust_step * thrust_mult
-        self._cf.commander.send_setpoint(0, 0, 0, 0)
-        # Make sure that the last packet leaves before the link is closed
-        # since the message queue is not flushed before closing
-        time.sleep(1)
+        for _ in range(30):
+            # Continuously send the zero setpoint until the drone is recognized as landed
+            # to prevent the supervisor from intervening due to missing regular setpoints
+            self._cf.commander.send_setpoint(0, 0, 0, 0)
+            time.sleep(0.1)
         self._cf.close_link()
 
 


### PR DESCRIPTION
In ramp examples where motors are gradually ramped, the supervisor assumes the drone is flying and requires continuous updated setpoints. Previously, a single zero setpoint was sent before sleeping, which leads to supervisor intervention due to missing regular setpoints. Now, zero setpoints are continuously sent for 3 seconds (after which the drone can be safely assumed to be landed), preventing locking.

Currently, this does not directly check with the supervisor if the drone has landed. Investigating a way to do this revealed that it is not straightforward. In the client, we check the supervisor states through a bitfield check, but there is no direct and easy way to access this information from the library. I will open a new issue to propose adding supervisor state reading functionality to the library, making it easier to access this information directly.

Fixes https://github.com/orgs/bitcraze/discussions/1852