### PR TITLE
Removed some global variables

### DIFF
--- a/examples/step-by-step/sbs_motion_commander.py
+++ b/examples/step-by-step/sbs_motion_commander.py
@@ -91,7 +91,6 @@ def take_off_simple(scf):
 
 def log_pos_callback(timestamp, data, logconf):
     print(data)
-    global position_estimate
     position_estimate[0] = data['stateEstimate.x']
     position_estimate[1] = data['stateEstimate.y']
 

--- a/examples/swarm/asynchronizedSwarm.py
+++ b/examples/swarm/asynchronizedSwarm.py
@@ -74,7 +74,6 @@ def arm(scf):
 
 
 def position_callback(uri, data):
-    global pos1, pos2
     if uri == URI1:
         pos1[0] = data['stateEstimate.x']
         pos1[1] = data['stateEstimate.y']

--- a/examples/swarm/leader-follower.py
+++ b/examples/swarm/leader-follower.py
@@ -106,8 +106,7 @@ def pos_to_vel(x1, y1, x2, y2, dist):
 
 
 def position_callback(uri, data):
-    global yaw1
-    global x1, y1, z1, x2, y2, z2, d
+    global d
     if uri == URI1:  # Follower
         x1.append(data['stateEstimate.x'])
         y1.append(data['stateEstimate.y'])


### PR DESCRIPTION
Lists in Python are mutable, meaning modifications inside one function will reflect globally wherever that list is used.
This caused Flake8 to fail.