### PR TITLE
Fix threads never closing.

### DIFF
--- a/cflib/crazyflie/link_statistics.py
+++ b/cflib/crazyflie/link_statistics.py
@@ -146,7 +146,7 @@ class Latency:
         """
         if self._ping_thread_instance is None or not self._ping_thread_instance.is_alive():
             self._stop_event.clear()
-            self._ping_thread_instance = Thread(target=self._ping_thread)
+            self._ping_thread_instance = Thread(target=self._ping_thread, name='ping_thread')
             self._ping_thread_instance.start()
 
     def stop(self):

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -29,6 +29,7 @@ When a Crazyflie is connected it's possible to download a TableOfContent of all
 the parameters that can be written/read.
 
 """
+import copy
 import errno
 import logging
 import struct
@@ -652,6 +653,7 @@ class _ParamUpdater(Thread):
             if self._useV2:
                 release_pattern = pk.data[:2]
                 if pk.channel == READ_CHANNEL:
+                    pk = copy.deepcopy(pk)  # Dont modify the original packet
                     pk.data = pk.data[:2] + pk.data[3:]
             else:
                 release_pattern = pk.data[:1]

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -519,7 +519,7 @@ class Param():
 class _ExtendedTypeFetcher(Thread):
 
     def __init__(self, cf, toc):
-        Thread.__init__(self)
+        Thread.__init__(self, name='ExtendedTypeFetcherThread')
         self.daemon = True
         self._lock = Lock()
 
@@ -598,7 +598,7 @@ class _ParamUpdater(Thread):
 
     def __init__(self, cf, useV2, updated_callback):
         """Initialize the thread"""
-        Thread.__init__(self)
+        Thread.__init__(self, name='ParamUpdaterThread')
         self.daemon = True
         self.wait_lock = Lock()
         self.cf = cf

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -295,7 +295,9 @@ class Param():
 
     def _disconnected(self, uri):
         """Disconnected callback from Crazyflie API"""
-        self.param_updater.close()
+        if self.param_updater is not None:
+            self.param_updater.close()
+            self.param_updater = None
 
         # Do not clear self.is_updated here as we might get spurious parameter updates later
 
@@ -307,6 +309,9 @@ class Param():
         """
         Request an update of the value for the supplied parameter.
         """
+        if self.param_updater is None:
+            self.param_updater = _ParamUpdater(self.cf, self._useV2, self._param_updated)
+            self.param_updater.start()
         self.param_updater.request_param_update(
             self.toc.get_element_id(complete_name))
 
@@ -573,6 +578,9 @@ class _ExtendedTypeFetcher(Thread):
                 self.request_queue.get(block=False)
         except Empty:
             pass
+        self.request_queue.put(None)  # Make sure we exit the run loop
+        self._should_close = True
+        self._cf.remove_port_callback(CRTPPort.PARAM, self._new_packet_cb)
 
         # Then force an unlock of the mutex if we are waiting for a packet
         # we didn't get back due to a disconnect for example.
@@ -584,6 +592,8 @@ class _ExtendedTypeFetcher(Thread):
     def run(self):
         while not self._should_close:
             pk = self.request_queue.get()  # Wait for request update
+            if pk is None:
+                continue
             self._lock.acquire()
             if self._cf.link:
                 self._req_param = struct.unpack('<H', pk.data[1:3])[0]
@@ -616,7 +626,9 @@ class _ParamUpdater(Thread):
                 self.request_queue.get(block=False)
         except Empty:
             pass
-
+        self.request_queue.put(None)  # Make sure we exit the run loop
+        self._should_close = True
+        self.cf.remove_port_callback(CRTPPort.PARAM, self._new_packet_cb)
         # Then force an unlock of the mutex if we are waiting for a packet
         # we didn't get back due to a disconnect for example.
         try:
@@ -677,6 +689,8 @@ class _ParamUpdater(Thread):
     def run(self):
         while not self._should_close:
             pk = self.request_queue.get()  # Wait for request update
+            if pk is None:
+                continue
             self.wait_lock.acquire()
             if self.cf.link:
                 if self._useV2:

--- a/cflib/crtp/radiodriver.py
+++ b/cflib/crtp/radiodriver.py
@@ -527,7 +527,7 @@ class _RadioDriverThread(threading.Thread):
     def __init__(self, radio, inQueue, outQueue,
                  radio_link_statistics_callback, link_error_callback, link, rate_limit: Optional[int]):
         """ Create the object """
-        threading.Thread.__init__(self)
+        threading.Thread.__init__(self, name='RadioDriverThread')
         self._radio = radio
         self._in_queue = inQueue
         self._out_queue = outQueue


### PR DESCRIPTION
There where some threads (param related) that would never close.
They would even keep their Crazyflie object alive forever. This would slow down performance over time. 

Fix this by making sure the threads exit by sending a None object to the queue and setting the should_close flag. 

Previously we where counting on this behavior and never created new thread objects upon reconnect of the same crazyflie object. So I added creation of the thread objects if there is no object (i.e the connection was closed). 
This way you can re-use the same Crazyflie object if you want (this is done in testing), or throw it away and create a new object. Both of these will create the correct number of threads. 

Did some cleanup by naming the threads for easier debugging. I also made sure the callbacks in param.py does not modify the original message. This could cause unknown side effects. 