### PR TITLE
ParamUpdater thread should only run when there is a connection

### DIFF
--- a/cflib/crazyflie/__init__.py
+++ b/cflib/crazyflie/__init__.py
@@ -393,7 +393,8 @@ class _IncomingPacketHandler(Thread):
     """Handles incoming packets and sends the data to the correct receivers"""
 
     def __init__(self, cf):
-        Thread.__init__(self)
+        Thread.__init__(self, name='IncomingPacketHandlerThread')
+        self.daemon = True
         self.cf = cf
         self.cb = []
 

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -155,9 +155,6 @@ class Param():
         self.all_update_callback = Caller()
         self.param_updater = None
 
-        self.param_updater = _ParamUpdater(self.cf, self._useV2, self._param_updated)
-        self.param_updater.start()
-
         self.cf.disconnected.add_callback(self._disconnected)
         self.cf.connection_requested.add_callback(self._connection_requested)
 
@@ -289,6 +286,8 @@ class Param():
 
     def _connection_requested(self, uri):
         # Reset the internal state on connect to make sure we have a clean state
+        self.param_updater = _ParamUpdater(self.cf, self._useV2, self._param_updated)
+        self.param_updater.start()
         self.is_updated = False
         self.toc = Toc()
         self.values = {}
@@ -312,8 +311,7 @@ class Param():
         Request an update of the value for the supplied parameter.
         """
         if self.param_updater is None:
-            self.param_updater = _ParamUpdater(self.cf, self._useV2, self._param_updated)
-            self.param_updater.start()
+            raise Exception('Param updater not initialized, did you call open_connection?')
         self.param_updater.request_param_update(
             self.toc.get_element_id(complete_name))
 

--- a/cflib/crazyflie/param.py
+++ b/cflib/crazyflie/param.py
@@ -295,6 +295,7 @@ class Param():
         self._initialized.clear()
 
     def _disconnected(self, uri):
+        logger.info('Disconnected, cleaning up threads')
         """Disconnected callback from Crazyflie API"""
         if self.param_updater is not None:
             self.param_updater.close()

--- a/cflib/crtp/radiodriver.py
+++ b/cflib/crtp/radiodriver.py
@@ -542,6 +542,7 @@ class _RadioDriverThread(threading.Thread):
 
         self._has_safelink = False
         self._link = link
+        self.daemon = True
 
     def stop(self):
         """ Stop the thread """


### PR DESCRIPTION
In this PR I added functionality so that the paramupdater thread will start when a connection is initiated, not when the Param object is created. 
This makes the thread only live while there is a connection. 

Also make some other threads daemons so they close when main program closes. 