### PR TITLE
Updated the table in lh geo solver

### DIFF
--- a/cflib/localization/lighthouse_geometry_solver.py
+++ b/cflib/localization/lighthouse_geometry_solver.py
@@ -99,38 +99,38 @@ class LighthouseGeometrySolver:
 
     An examples matrix:
 
-                        bs0_pose, bs1_pose, bs2_pose, bs3_pose, cf1_pose, cf2_pose, ...
+    |                         | bs0_pose | bs1_pose | bs2_pose | bs3_pose | cf1_pose | cf2_pose |
+    |-------------------------|----------|----------|----------|----------|----------|----------|
+    | cf0/bs2/sens0/ang0      |          |          | X        |          |          |          |
+    | cf0/bs2/sens0/ang1      |          |          | X        |          |          |          |
+    | cf0/bs2/sens1/ang0      |          |          | X        |          |          |          |
+    | cf0/bs2/sens1/ang1      |          |          | X        |          |          |          |
+    |                         |          |          |          |          |          |          |
+    | cf0/bs3/sens0/ang0      |          |          |          | X        |          |          |
+    | cf0/bs3/sens0/ang1      |          |          |          | X        |          |          |
+    | cf0/bs3/sens1/ang0      |          |          |          | X        |          |          |
+    | cf0/bs3/sens1/ang1      |          |          |          | X        |          |          |
+    |                         |          |          |          |          |          |          |
+    | cf1/bs1/sens0/ang0      |          | X        |          |          | X        |          |
+    | cf1/bs1/sens0/ang1      |          | X        |          |          | X        |          |
+    | cf1/bs1/sens1/ang0      |          | X        |          |          | X        |          |
+    | cf1/bs1/sens1/ang1      |          | X        |          |          | X        |          |
+    |                         |          |          |          |          |          |          |
+    | cf1/bs2/sens0/ang0      |          |          | X        |          | X        |          |
+    | cf1/bs2/sens0/ang1      |          |          | X        |          | X        |          |
+    | cf1/bs2/sens1/ang0      |          |          | X        |          | X        |          |
+    | cf1/bs2/sens1/ang1      |          |          | X        |          | X        |          |
+    |                         |          |          |          |          |          |          |
+    | cf2/bs1/sens0/ang0      |          | X        |          |          |          | X        |
+    | cf2/bs1/sens0/ang1      |          | X        |          |          |          | X        |
+    | cf2/bs1/sens1/ang0      |          | X        |          |          |          | X        |
+    | cf2/bs1/sens1/ang1      |          | X        |          |          |          | X        |
+    |                         |          |          |          |          |          |          |
+    | cf2/bs3/sens0/ang0      |          |          |          | X        |          | X        |
+    | cf2/bs3/sens0/ang1      |          |          |          | X        |          | X        |
+    | cf2/bs3/sens1/ang0      |          |          |          | X        |          | X        |
+    | cf2/bs3/sens1/ang1      |          |          |          | X        |          | X        |
 
-    cf0/bs2/sens0/ang0                        X
-    cf0/bs2/sens0/ang1                        X
-    cf0/bs2/sens1/ang0                        X
-    cf0/bs2/sens1/ang1                        X
-    ...
-    cf0/bs3/sens0/ang0                                  X
-    cf0/bs3/sens0/ang1                                  X
-    cf0/bs3/sens1/ang0                                  X
-    cf0/bs3/sens1/ang1                                  X
-    ...
-    cf1/bs1/sens0/ang0              X                             X
-    cf1/bs1/sens0/ang1              X                             X
-    cf1/bs1/sens1/ang0              X                             X
-    cf1/bs1/sens1/ang1              X                             X
-    ...
-    cf1/bs2/sens0/ang0                        X                   X
-    cf1/bs2/sens0/ang1                        X                   X
-    cf1/bs2/sens1/ang0                        X                   X
-    cf1/bs2/sens1/ang1                        X                   X
-    ...
-    cf2/bs1/sens0/ang0              X                                      X
-    cf2/bs1/sens0/ang1              X                                      X
-    cf2/bs1/sens1/ang0              X                                      X
-    cf2/bs1/sens1/ang1              X                                      X
-    ...
-    cf2/bs3/sens0/ang0                                  X                  X
-    cf2/bs3/sens0/ang1                                  X                  X
-    cf2/bs3/sens1/ang0                                  X                  X
-    cf2/bs3/sens1/ang1                                  X                  X
-    ...
     """
 
     @classmethod


### PR DESCRIPTION
Based on [this issue](https://github.com/bitcraze/crazyflie-lib-python/issues/335), I updated the table in [lighthouse_geometry_solver.py](https://github.com/bitcraze/crazyflie-lib-python/blob/6e93153c1be43082dec3471014f0de6db59b32e6/cflib/localization/lighthouse_geometry_solver.py) to render properly when displayed in the [web](https://www.bitcraze.io/documentation/repository/crazyflie-lib-python/master/api/cflib/localization/lighthouse_geometry_solver/#classes). It should look like this:
![image](https://github.com/user-attachments/assets/d2eb99b9-de84-44b4-94f8-0d370ec20489)
