### PR TITLE
Ensure proper thread and link cleanup on failed Crazyflie connections / disconnects

### DIFF
--- a/cflib/bootloader/cloader.py
+++ b/cflib/bootloader/cloader.py
@@ -114,7 +114,7 @@ class Cloader:
                 self.link = cflib.crtp.get_link_driver(f'radio://0/0/2M/{address}?safelink=0')
                 time.sleep(0.5)
                 return True
-
+        self.link.close()
         return False
 
     def reset_to_firmware(self, target_id: int, boot_delay: float = 0.0) -> bool:

--- a/cflib/crazyflie/__init__.py
+++ b/cflib/crazyflie/__init__.py
@@ -32,10 +32,10 @@ firmware which makes the mapping 1:1 in most cases.
 """
 import datetime
 import logging
-import time
 import warnings
 from collections import namedtuple
 from threading import current_thread
+from threading import Event
 from threading import Lock
 from threading import Thread
 from threading import Timer
@@ -284,6 +284,14 @@ class Crazyflie():
         if (self.link is not None):
             self.link.close()
             self.link = None
+        if self.incoming:
+            callbacks = list(self.incoming.cb)
+            if self.incoming.is_alive():
+                self.incoming.stop()
+                self.incoming.join()
+            self.incoming = _IncomingPacketHandler(self)
+            self.incoming.cb = callbacks
+            self.incoming.daemon = True
         self._answer_patterns = {}
         self.disconnected.call(self.link_uri)
         self.state = State.DISCONNECTED
@@ -397,6 +405,7 @@ class _IncomingPacketHandler(Thread):
         self.daemon = True
         self.cf = cf
         self.cb = []
+        self._stop_event = Event()
 
     def add_port_callback(self, port, cb):
         """Add a callback for data that comes on a specific port"""
@@ -431,10 +440,14 @@ class _IncomingPacketHandler(Thread):
                     port_callback.callback == cb:
                 self.cb.remove(port_callback)
 
+    def stop(self):
+        """Signal the thread to stop."""
+        self._stop_event.set()
+
     def run(self):
-        while True:
+        while not self._stop_event.is_set():
             if self.cf.link is None:
-                time.sleep(1)
+                self._stop_event.wait(1)
                 continue
             pk = self.cf.link.receive_packet(1)
 

--- a/cflib/crazyflie/__init__.py
+++ b/cflib/crazyflie/__init__.py
@@ -288,7 +288,7 @@ class Crazyflie():
             callbacks = list(self.incoming.cb)
             if self.incoming.is_alive():
                 self.incoming.stop()
-                self.incoming.join()
+                self.incoming.join(timeout=1)
             self.incoming = _IncomingPacketHandler(self)
             self.incoming.cb = callbacks
             self.incoming.daemon = True

--- a/cflib/crazyflie/syncCrazyflie.py
+++ b/cflib/crazyflie/syncCrazyflie.py
@@ -92,6 +92,7 @@ class SyncCrazyflie:
         if not self._is_link_open:
             self._remove_callbacks()
             self._params_updated_event.clear()
+            self.cf.close_link()
             raise Exception(self._error_message)
 
     def wait_for_params(self):


### PR DESCRIPTION
- Close RadioDriverThread upon failed reset to bootload

This change ensures the radio link is properly closed when `reset_to_bootloader` times out (e.g., Crazyflie is off), preventing accumulation of RadioDriverThread instances on repeated failures.

- Close IncomingPacketHandlerThread upon link closure

Ensures IncomingPacketHandler threads are stopped and replaced when the link is closed, preserving callbacks for reconnects.

- Close link upon failed open link attempt with SyncCrazyflie

Ensures link is fully closed upon failed attempt to open link

---

Together, these changes address much of #554. Still, more underlying issues remain. Addressing them fully will require deeper refactoring rather than patch-level fixes.