### PR TITLE
Adding a simple mocap example with multiple cf/rigid bodies

### DIFF
--- a/examples/mocap/mocap_swarm.py
+++ b/examples/mocap/mocap_swarm.py
@@ -44,14 +44,13 @@ from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
 mocap_system_type = 'optitrack'
 
 # The host name or ip address of the mocap system
-# host_name = '192.168.5.21'
 host_name = '10.223.0.31'
 
 # Maps the URIs to the rigid-body names as streamed by, e.g., OptiTrack's Motive
 swarm_config = [
     ('radio://0/80/2M/E7E7E7E7E7', 'cf1'),
-    #   ('radio://0/90/2M/E7E7E7E7E8', 'cf2'),
-    #   ('radio://0/100/2M/E7E7E7E7E9', 'cf3'),
+    #   ('radio://0/80/2M/E7E7E7E7E8', 'cf2'),
+    #   ('radio://0/80/2M/E7E7E7E7E9', 'cf3'),
     #   Add more URIs if you want more copters in the swarm
 ]
 

--- a/examples/mocap/mocap_swarm_multi_commander.py
+++ b/examples/mocap/mocap_swarm_multi_commander.py
@@ -45,14 +45,13 @@ from cflib.positioning.position_hl_commander import PositionHlCommander
 mocap_system_type = 'optitrack'
 
 # The host name or ip address of the mocap system
-# host_name = '192.168.5.21'
 host_name = '10.223.0.31'
 
 # Maps the URIs to the rigid-body names as streamed by, e.g., OptiTrack's Motive
 swarm_config = [
     ('radio://0/80/2M/E7E7E7E7E7', 'cf1'),
-    #    ('radio://0/90/2M/E7E7E7E7E8', 'cf2'),
-    #    ('radio://0/100/2M/E7E7E7E7E9', 'cf3'),
+    #    ('radio://0/80/2M/E7E7E7E7E8', 'cf2'),
+    #    ('radio://0/80/2M/E7E7E7E7E9', 'cf3'),
     #   Add more URIs if you want more copters in the swarm
 ]
 


### PR DESCRIPTION
I thought it could be useful to add a very simple extension of `mocap_hl_commander.py` to connect to multiple Crazyflies, even just for debugging purposes
- only sending positions from the mocap system
- using the motion commander as well
- tested with optitrack