### PR TITLE
Include Qualisys SDK as optional dependency

### DIFF
--- a/examples/mocap/qualisys_hl_commander.py
+++ b/examples/mocap/qualisys_hl_commander.py
@@ -26,6 +26,9 @@ figure 8.
 
 Set the uri to the radio settings of the Crazyflie and modify the
 rigid_body_name to match the name of the Crazyflie in QTM.
+
+Requires the qualisys optional dependency:
+    pip install cflib[qualisys]
 """
 import asyncio
 import math

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ Issues = "https://github.com/bitcraze/crazyflie-lib-python/issues"
 
 [project.optional-dependencies]
 dev = ["pre-commit"]
+qualisys = ["qtm-rt>=3.0.2"]
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
Add qtm-rt as optional [qualisys] dependency to help users discover the required package for the Qualisys mocap example. The installation effort is the same, but now it's clear which package is needed.

Users with Qualisys systems can now install with: pip install cflib[qualisys]