### PR TITLE
Fix examples requesting thread closure from within same thread

### DIFF
--- a/examples/memory/erase-ow.py
+++ b/examples/memory/erase-ow.py
@@ -67,6 +67,7 @@ class EEPROMExample:
 
         # Variable used to keep main loop occupied until disconnect
         self.is_connected = True
+        self.should_disconnect = False
 
     def _connected(self, link_uri):
         """ This callback is called form the Crazyflie API when a Crazyflie
@@ -97,7 +98,7 @@ class EEPROMExample:
         for key in mem.elements:
             print('\t\t{}={}'.format(key, mem.elements[key]))
 
-        self._cf.close_link()
+        self.should_disconnect = True
 
     def _stab_log_error(self, logconf, msg):
         """Callback from the log API when an error occurs"""
@@ -137,6 +138,8 @@ if __name__ == '__main__':
     # are just waiting until we are disconnected.
     try:
         while le.is_connected:
+            if le.should_disconnect:
+                le._cf.close_link()
             time.sleep(1)
     except KeyboardInterrupt:
         sys.exit(1)

--- a/examples/memory/read-eeprom.py
+++ b/examples/memory/read-eeprom.py
@@ -64,6 +64,7 @@ class EEPROMExample:
 
         # Variable used to keep main loop occupied until disconnect
         self.is_connected = True
+        self.should_disconnect = False
 
     def _connected(self, link_uri):
         """ This callback is called form the Crazyflie API when a Crazyflie
@@ -88,7 +89,7 @@ class EEPROMExample:
 
         self._mems_to_update -= 1
         if self._mems_to_update == 0:
-            self._cf.close_link()
+            self.should_disconnect = True
 
     def _stab_log_error(self, logconf, msg):
         """Callback from the log API when an error occurs"""
@@ -126,6 +127,8 @@ if __name__ == '__main__':
     # are just waiting until we are disconnected.
     try:
         while le.is_connected:
+            if le.should_disconnect:
+                le._cf.close_link()
             time.sleep(1)
     except KeyboardInterrupt:
         sys.exit(1)

--- a/examples/memory/write-eeprom.py
+++ b/examples/memory/write-eeprom.py
@@ -65,6 +65,7 @@ class EEPROMExample:
 
         # Variable used to keep main loop occupied until disconnect
         self.is_connected = True
+        self.should_disconnect = False
 
     def _connected(self, link_uri):
         """ This callback is called form the Crazyflie API when a Crazyflie
@@ -100,7 +101,7 @@ class EEPROMExample:
         for key in mem.elements:
             print('\t\t{}={}'.format(key, mem.elements[key]))
 
-        self._cf.close_link()
+        self.should_disconnect = True
 
     def _stab_log_error(self, logconf, msg):
         """Callback from the log API when an error occurs"""
@@ -138,6 +139,8 @@ if __name__ == '__main__':
     # are just waiting until we are disconnected.
     try:
         while le.is_connected:
+            if le.should_disconnect:
+                le._cf.close_link()
             time.sleep(1)
     except KeyboardInterrupt:
         sys.exit(1)

--- a/examples/memory/write-ow.py
+++ b/examples/memory/write-ow.py
@@ -61,6 +61,7 @@ class WriteOwExample:
 
         # Variable used to keep main loop occupied until disconnect
         self.is_connected = True
+        self.should_disconnect = False
 
     def _connected(self, link_uri):
         """ This callback is called form the Crazyflie API when a Crazyflie
@@ -103,7 +104,7 @@ class WriteOwExample:
         for key in mem.elements:
             print('\t\t{}={}'.format(key, mem.elements[key]))
 
-        self._cf.close_link()
+        self.should_disconnect = True
 
     def _stab_log_error(self, logconf, msg):
         """Callback from the log API when an error occurs"""
@@ -141,6 +142,8 @@ if __name__ == '__main__':
     # are just waiting until we are disconnected.
     try:
         while le.is_connected:
+            if le.should_disconnect:
+                le._cf.close_link()
             time.sleep(1)
     except KeyboardInterrupt:
         sys.exit(1)

--- a/examples/parameters/basicparam.py
+++ b/examples/parameters/basicparam.py
@@ -65,6 +65,7 @@ class ParamExample:
 
         # Variable used to keep main loop occupied until disconnect
         self.is_connected = True
+        self.should_disconnect = False
 
         self._param_check_list = []
         self._param_groups = []
@@ -129,8 +130,8 @@ class ParamExample:
         """Callback for pid_attitude.pitch_kd"""
         print('Read back: {0}={1}'.format(name, value))
 
-        # This is the end of the example, close link
-        self._cf.close_link()
+        # This is the end of the example, signal to close link
+        self.should_disconnect = True
 
     def _connection_failed(self, link_uri, msg):
         """Callback when connection initial connection fails (i.e no Crazyflie
@@ -160,4 +161,6 @@ if __name__ == '__main__':
     # alive, so this is where your application should do something. In our
     # case we are just waiting until we are disconnected.
     while pe.is_connected:
+        if pe.should_disconnect:
+            pe._cf.close_link()
         time.sleep(1)


### PR DESCRIPTION
70e6f7d8af8224f266ea0b363bbf11d3c68813c2 closes IncomingPacketHandlerThread upon link closure. This broke examples using a callback on IncomingPacketHandlerThread to close the link directly. This PR prevents this error by avoiding requests to close the IncomingPacketHandler thread from within its own callbacks. Uses flag-based approach instead.