### PR TITLE
Fix Lighthouse estimation documentation anchor

### DIFF
--- a/docs/functional-areas/lighthouse.md
+++ b/docs/functional-areas/lighthouse.md
@@ -109,7 +109,7 @@ Each `LhCfPoseSample` is tagged with a `LhCfPoseSampleType` that determines how 
 | `XYZ_SPACE` | Additional positions anywhere in 3D space, used only to improve the solver's accuracy. Optional; more is better. | No |
 | `VERIFICATION` | Positions not used during estimation, only used to independently verify the result afterwards. | No |
 
-`ORIGIN`, `X_AXIS`, and `XY_PLANE` samples are mandatory: if any of these are missing or invalid, estimation cannot proceed. `XYZ_SPACE` samples improve accuracy but are not required. Ambiguous samples (see [Initial estimation](#initial-estimation)) that are mandatory are kept in the pipeline but cause `progress_is_ok` to be set to `False`; non-mandatory ambiguous samples are silently dropped.
+`ORIGIN`, `X_AXIS`, and `XY_PLANE` samples are mandatory: if any of these are missing or invalid, estimation cannot proceed. `XYZ_SPACE` samples improve accuracy but are not required. Ambiguous samples (see [Initial estimation](#2-initial-estimation-ippe)) that are mandatory are kept in the pipeline but cause `progress_is_ok` to be set to `False`; non-mandatory ambiguous samples are silently dropped.
 
 ## Estimation pipeline
 


### PR DESCRIPTION
## Summary

- Point the Initial estimation link at the generated `#2-initial-estimation-ippe` anchor.

## Why

The public website imports the `master` documentation and renders it with Kramdown's GFM parser. The previous fragment omitted the heading's numeric prefix and `IPPE` suffix, so it did not resolve. HTML-Proofer consequently blocked the `docker-int-web` release build.

## Validation

- Rendered the document with the `bitcraze/web-builder` GFM/Kramdown versions.
- Verified every same-page fragment resolves to a generated element ID.
