### PR TITLE
Add default file to example persistent_params_from_file

### DIFF
--- a/examples/parameters/params.yaml
+++ b/examples/parameters/params.yaml
@@ -1,0 +1,7 @@
+params:
+  activeMarker.back:
+    default_value: 3
+    is_stored: true
+    stored_value: 30
+type: persistent_param_state
+version: '1'

--- a/examples/parameters/persistent_params_from_file.py
+++ b/examples/parameters/persistent_params_from_file.py
@@ -47,7 +47,7 @@ logging.basicConfig(level=logging.ERROR)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-f', '--file', type=str, default='params.yaml',
+    parser.add_argument('-f', '--file', type=str, default='persistent_params_from_file.yaml',
                         help='The yaml file containing the arguments. (default: params.yaml)')
     args = parser.parse_args()
 

--- a/examples/parameters/persistent_params_from_file.py
+++ b/examples/parameters/persistent_params_from_file.py
@@ -33,6 +33,7 @@ version: '1'
 """
 import argparse
 import logging
+import os
 
 import cflib.crtp
 from cflib.crazyflie import Crazyflie
@@ -45,9 +46,11 @@ uri = uri_helper.uri_from_env(default='radio://0/80/2M/E7E7E7E7E7')
 # Only output errors from the logging framework
 logging.basicConfig(level=logging.ERROR)
 
+default_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'persistent_params_from_file.yaml')
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-f', '--file', type=str, default='persistent_params_from_file.yaml',
+    parser.add_argument('-f', '--file', type=str, default=default_file,
                         help='The yaml file containing the arguments. (default: params.yaml)')
     args = parser.parse_args()
 

--- a/examples/parameters/persistent_params_from_file.py
+++ b/examples/parameters/persistent_params_from_file.py
@@ -40,16 +40,15 @@ from cflib.crazyflie.syncCrazyflie import SyncCrazyflie
 from cflib.utils import uri_helper
 from cflib.utils.param_file_helper import ParamFileHelper
 
-
 uri = uri_helper.uri_from_env(default='radio://0/80/2M/E7E7E7E7E7')
 
 # Only output errors from the logging framework
 logging.basicConfig(level=logging.ERROR)
 
-
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-f', '--file', type=str, help='The yaml file containing the arguments. ')
+    parser.add_argument('-f', '--file', type=str, default='params.yaml',
+                        help='The yaml file containing the arguments. (default: params.yaml)')
     args = parser.parse_args()
 
     cflib.crtp.init_drivers()

--- a/examples/parameters/persistent_params_from_file.yaml
+++ b/examples/parameters/persistent_params_from_file.yaml
@@ -1,3 +1,4 @@
+# Example file for writing persistent parameters using a file
 params:
   activeMarker.back:
     default_value: 3


### PR DESCRIPTION
Add default file to example `persistent_params_from_file.py`.

Tested:

```
$ python persistent_params_from_file.py
Persistent params: stored activeMarker.back!
```