### PR TITLE
Us the same `link` instance in `send_packet()`

### DIFF
--- a/cflib/crazyflie/__init__.py
+++ b/cflib/crazyflie/__init__.py
@@ -360,9 +360,10 @@ class Crazyflie():
             raise Exception('Data part of packet is too large')
 
         self._send_lock.acquire()
-        if self.link is not None:
+        link = self.link
+        if link is not None:
             if len(expected_reply) > 0 and not resend and \
-                    self.link.needs_resending:
+                    link.needs_resending:
                 pattern = (pk.header,) + expected_reply
                 logger.debug(
                     'Sending packet and expecting the %s pattern back',
@@ -387,7 +388,7 @@ class Crazyflie():
                 else:
                     logger.debug('Resend requested, but no pattern found: %s',
                                  self._answer_patterns)
-            self.link.send_packet(pk)
+            link.send_packet(pk)
             self.packet_sent.call(pk)
         self._send_lock.release()
 


### PR DESCRIPTION
When flashing a Crazyflie 2.0 via cfclient, most of the times the process got stuck in "identifying decks to update", with this error:
```
crazyflie-lib-python/cflib/crazyflie/__init__.py", line 390, in send_packet
    self.link.send_packet(pk)
    ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'send_packet'
```

This was caused by `send_packet()` reading `self.link` twice: first in `if self.link is not None: `, and then in `elf.link.send_packet(pk)`. Between these reads, other threads (e.g. `close_link()`) can set the link to `None`.

This PR fixes that by reading self.link only once, so the commands in `send_packet()` will always agree.