### PR TITLE
Fix LogConfig ID lifecycle

### DIFF
--- a/cflib/crazyflie/log.py
+++ b/cflib/crazyflie/log.py
@@ -280,6 +280,15 @@ class LogConfig(object):
 
     def create(self):
         """Save the log configuration in the Crazyflie"""
+        cf = self.cf
+        if cf is None or self.id is None:
+            raise LogConfigError(
+                'Log configuration must be added before it can be created')
+        with cf.log._command_lock:
+            cf.log._require_registered(self)
+            self._create()
+
+    def _create(self):
         command = self._cmd_create_block()
         next_to_add = 0
         is_done = False
@@ -325,32 +334,38 @@ class LogConfig(object):
         if cf is None or self.id is None:
             raise LogConfigError(
                 'Log configuration must be added before it can be started')
-        if (cf.link is not None):
-            if (self._added is False):
-                self.create()
-                logger.debug('First time block is started, add block')
-            else:
-                logger.debug('Block already registered, starting logging'
-                             ' for id=%d', self.id)
-                pk = CRTPPacket()
-                pk.set_header(5, CHAN_SETTINGS)
-                pk.data = (CMD_START_LOGGING, self.id, self.period)
-                self.cf.send_packet(pk, expected_reply=(
-                    CMD_START_LOGGING, self.id))
+        with cf.log._command_lock:
+            cf.log._require_registered(self)
+            if (cf.link is not None):
+                if (self._added is False):
+                    self._create()
+                    logger.debug('First time block is started, add block')
+                else:
+                    logger.debug(
+                        'Block already registered, starting logging for id=%d',
+                        self.id)
+                    pk = CRTPPacket()
+                    pk.set_header(5, CHAN_SETTINGS)
+                    pk.data = (CMD_START_LOGGING, self.id, self.period)
+                    cf.send_packet(pk, expected_reply=(
+                        CMD_START_LOGGING, self.id))
 
     def stop(self):
         """Stop the logging for this entry"""
         cf = self.cf
-        block_id = self.id
-        if cf is None or block_id is None:
+        if cf is None or self.id is None:
             return
-        if (cf.link is not None):
-            logger.debug('Sending stop logging for block id=%d', block_id)
-            pk = CRTPPacket()
-            pk.set_header(5, CHAN_SETTINGS)
-            pk.data = (CMD_STOP_LOGGING, block_id)
-            cf.send_packet(
-                pk, expected_reply=(CMD_STOP_LOGGING, block_id))
+        with cf.log._command_lock:
+            if not cf.log._is_registered(self):
+                return
+            block_id = self.id
+            if (cf.link is not None):
+                logger.debug('Sending stop logging for block id=%d', block_id)
+                pk = CRTPPacket()
+                pk.set_header(5, CHAN_SETTINGS)
+                pk.data = (CMD_STOP_LOGGING, block_id)
+                cf.send_packet(
+                    pk, expected_reply=(CMD_STOP_LOGGING, block_id))
 
     def delete(self):
         """Delete this entry in the Crazyflie"""
@@ -627,6 +642,17 @@ class Log():
                 if block.id == id:
                     return block
         return None
+
+    def _is_registered(self, logconf):
+        with self._registration_lock:
+            return (self._ids_ready and
+                    logconf in self.log_blocks and
+                    logconf.cf is self.cf and
+                    logconf.id is not None)
+
+    def _require_registered(self, logconf):
+        if not self._is_registered(logconf):
+            raise LogConfigError('Log configuration is not registered')
 
     def _retire_config(self, logconf, block_id):
         with self._registration_lock:

--- a/cflib/crazyflie/log.py
+++ b/cflib/crazyflie/log.py
@@ -169,6 +169,23 @@ class LogConfig(object):
     def _get_effective_variables(self):
         return self.variables + self._resolved_default_variables
 
+    def _detach(self):
+        previous_state = (self.started, self.added)
+        self._started = False
+        self._added = False
+        self._delete_pending = False
+        self.pending = False
+        self.id = None
+        self.cf = None
+        self._resolved_default_variables = []
+        return previous_state
+
+    def _call_detached_callbacks(self, was_started, was_added):
+        if was_started:
+            self.started_cb.call(self, False)
+        if was_added:
+            self.added_cb.call(self, False)
+
     def add_variable(self, name, fetch_as=None):
         """Add a new variable to the configuration.
 
@@ -587,20 +604,10 @@ class Log():
 
             callbacks = []
             for block in blocks:
-                callbacks.append((block, block.started, block.added))
-                block._started = False
-                block._added = False
-                block._delete_pending = False
-                block.pending = False
-                block.id = None
-                block.cf = None
-                block._resolved_default_variables = []
+                callbacks.append((block, block._detach()))
 
-        for block, was_started, was_added in callbacks:
-            if was_started:
-                block.started_cb.call(block, False)
-            if was_added:
-                block.added_cb.call(block, False)
+        for block, previous_state in callbacks:
+            block._call_detached_callbacks(*previous_state)
         return True
 
     def _disconnected(self, uri):
@@ -620,22 +627,12 @@ class Log():
                     not logconf._delete_pending):
                 return False
 
-            was_started = logconf.started
-            was_added = logconf.added
             self.log_blocks.remove(logconf)
-            self._available_config_ids.append(block_id)
-            logconf._started = False
-            logconf._added = False
-            logconf._delete_pending = False
-            logconf.pending = False
-            logconf.id = None
-            logconf.cf = None
-            logconf._resolved_default_variables = []
+            if self._ids_ready:
+                self._available_config_ids.append(block_id)
+            previous_state = logconf._detach()
 
-        if was_started:
-            logconf.started_cb.call(logconf, False)
-        if was_added:
-            logconf.added_cb.call(logconf, False)
+        logconf._call_detached_callbacks(*previous_state)
         return True
 
     def _delete_config(self, logconf):
@@ -652,7 +649,15 @@ class Log():
         pk = CRTPPacket()
         pk.set_header(CRTPPort.LOGGING, CHAN_SETTINGS)
         pk.data = (CMD_DELETE_BLOCK, block_id)
-        self.cf.send_packet(pk, expected_reply=(CMD_DELETE_BLOCK, block_id))
+        try:
+            self.cf.send_packet(
+                pk, expected_reply=(CMD_DELETE_BLOCK, block_id))
+        except Exception:
+            with self._registration_lock:
+                if (logconf.id == block_id and
+                        logconf._delete_pending):
+                    logconf._delete_pending = False
+            raise
 
     def _new_packet_cb(self, packet):
         """Callback for newly arrived packets with TOC information"""
@@ -732,6 +737,9 @@ class Log():
 
             if (cmd == CMD_RESET_LOGGING):
                 if error_status != 0x00:
+                    with self._registration_lock:
+                        if self._reset_pending:
+                            self._reset_pending = False
                     return
 
                 reset_completed = self._detach_all_configs(

--- a/cflib/crazyflie/log.py
+++ b/cflib/crazyflie/log.py
@@ -52,6 +52,8 @@ specified period.
 import errno
 import logging
 import struct
+from collections import deque
+from threading import Lock
 
 from .toc import Toc
 from .toc import TocFetcher
@@ -60,7 +62,7 @@ from cflib.crtp.crtpstack import CRTPPort
 from cflib.utils.callbacks import Caller
 
 __author__ = 'Bitcraze AB'
-__all__ = ['Log', 'LogTocElement']
+__all__ = ['Log', 'LogConfigError', 'LogTocElement']
 
 # Channels used for the logging port
 CHAN_TOC = 0
@@ -90,6 +92,10 @@ GET_TOC_ELEMENT = 'GET_TOC_ELEMENT'
 
 
 logger = logging.getLogger(__name__)
+
+
+class LogConfigError(Exception):
+    """Raised when a log configuration cannot change lifecycle state."""
 
 
 class LogVariable():
@@ -143,8 +149,8 @@ class LogConfig(object):
         self.added_cb = Caller()
         self.err_no = 0
 
-        # These 3 variables are set by the log subsystem when the bock is added
-        self.id = 0
+        # These 3 variables are set by the log subsystem when the block is added
+        self.id = None
         self.cf = None
         self.useV2 = False
 
@@ -152,11 +158,16 @@ class LogConfig(object):
         self.period_in_ms = period_in_ms
         self._added = False
         self._started = False
+        self._delete_pending = False
         self.pending = False
         self.valid = False
         self.variables = []
         self.default_fetch_as = []
+        self._resolved_default_variables = []
         self.name = name
+
+    def _get_effective_variables(self):
+        return self.variables + self._resolved_default_variables
 
     def add_variable(self, name, fetch_as=None):
         """Add a new variable to the configuration.
@@ -220,9 +231,10 @@ class LogConfig(object):
             return CMD_APPEND_BLOCK
 
     def _setup_log_elements(self, pk, next_to_add):
+        variables = self._get_effective_variables()
         i = next_to_add
-        for i in range(next_to_add, len(self.variables)):
-            var = self.variables[i]
+        for i in range(next_to_add, len(variables)):
+            var = variables[i]
             if (var.is_toc_variable() is False):  # Memory location
                 logger.debug('Logging to raw memory %d, 0x%04X',
                              var.get_storage_and_fetch_byte(), var.address)
@@ -260,14 +272,15 @@ class LogConfig(object):
         for block in self.cf.log.log_blocks:
             if block.pending or block.added or block.started:
                 pending += 1
-                num_variables += len(block.variables)
+                num_variables += len(block._get_effective_variables())
 
         if pending < Log.MAX_BLOCKS:
             #
             # The Crazyflie firmware can only handle 128 variables before
             # erroring out with ENOMEM.
             #
-            if num_variables + len(self.variables) > Log.MAX_VARIABLES:
+            if (num_variables + len(self._get_effective_variables()) >
+                    Log.MAX_VARIABLES):
                 raise AttributeError(
                     ('Adding this configuration would exceed max number '
                      'of variables (%d)' % Log.MAX_VARIABLES)
@@ -291,7 +304,11 @@ class LogConfig(object):
 
     def start(self):
         """Start the logging for this entry"""
-        if (self.cf.link is not None):
+        cf = self.cf
+        if cf is None or self.id is None:
+            raise LogConfigError(
+                'Log configuration must be added before it can be started')
+        if (cf.link is not None):
             if (self._added is False):
                 self.create()
                 logger.debug('First time block is started, add block')
@@ -306,37 +323,30 @@ class LogConfig(object):
 
     def stop(self):
         """Stop the logging for this entry"""
-        if (self.cf.link is not None):
-            if (self.id is None):
-                logger.warning('Stopping block, but no block registered')
-            else:
-                logger.debug('Sending stop logging for block id=%d', self.id)
-                pk = CRTPPacket()
-                pk.set_header(5, CHAN_SETTINGS)
-                pk.data = (CMD_STOP_LOGGING, self.id)
-                self.cf.send_packet(
-                    pk, expected_reply=(CMD_STOP_LOGGING, self.id))
+        cf = self.cf
+        block_id = self.id
+        if cf is None or block_id is None:
+            return
+        if (cf.link is not None):
+            logger.debug('Sending stop logging for block id=%d', block_id)
+            pk = CRTPPacket()
+            pk.set_header(5, CHAN_SETTINGS)
+            pk.data = (CMD_STOP_LOGGING, block_id)
+            cf.send_packet(
+                pk, expected_reply=(CMD_STOP_LOGGING, block_id))
 
     def delete(self):
         """Delete this entry in the Crazyflie"""
-        if (self.cf.link is not None):
-            if (self.id is None):
-                logger.warning('Delete block, but no block registered')
-            else:
-                logger.debug('LogEntry: Sending delete logging for block id=%d'
-                             % self.id)
-                pk = CRTPPacket()
-                pk.set_header(5, CHAN_SETTINGS)
-                pk.data = (CMD_DELETE_BLOCK, self.id)
-                self.cf.send_packet(
-                    pk, expected_reply=(CMD_DELETE_BLOCK, self.id))
+        cf = self.cf
+        if cf is not None and self.id is not None:
+            cf.log._delete_config(self)
 
     def unpack_log_data(self, log_data, timestamp):
         """Unpack received logging data so it represent real values according
         to the configuration in the entry"""
         ret_data = {}
         data_index = 0
-        for var in self.variables:
+        for var in self._get_effective_variables():
             size = LogTocElement.get_size_from_id(var.fetch_as)
             name = var.name
             unpackstring = LogTocElement.get_unpack_string_from_id(
@@ -415,6 +425,7 @@ class Log():
     """Create log configuration"""
 
     MAX_BLOCKS = 16
+    MAX_CONFIG_IDS = 256
     MAX_VARIABLES = 128
 
     # These codes can be decoded using os.stderror, but
@@ -436,6 +447,7 @@ class Log():
         self.cf = crazyflie
         self.toc = None
         self.cf.add_port_callback(CRTPPort.LOGGING, self._new_packet_cb)
+        self.cf.disconnected.add_callback(self._disconnected)
 
         self.toc_updated = Caller()
         self.state = IDLE
@@ -444,7 +456,10 @@ class Log():
         self._refresh_callback = None
         self._toc_cache = None
 
-        self._config_id_counter = 1
+        self._registration_lock = Lock()
+        self._available_config_ids = deque()
+        self._ids_ready = False
+        self._reset_pending = False
 
         self._useV2 = False
 
@@ -459,13 +474,21 @@ class Log():
         connected when calling this method, otherwise it will fail."""
 
         if not self.cf.link:
-            logger.error('Cannot add configs without being connected to a '
-                         'Crazyflie!')
-            return
+            raise LogConfigError(
+                'Cannot add log configurations without a connection')
+
+        with self._registration_lock:
+            if logconf.id is not None or logconf.cf is not None:
+                raise LogConfigError(
+                    'Log configuration is already registered')
+            if not self._ids_ready:
+                raise LogConfigError(
+                    'Log configuration IDs are not ready')
 
         # If the log configuration contains variables that we added without
         # type (i.e we want the stored as type for fetching as well) then
         # resolve this now and add them to the block again.
+        resolved_default_variables = []
         for name in logconf.default_fetch_as:
             var = self.toc.get_element_by_complete_name(name)
             if not var:
@@ -473,15 +496,14 @@ class Log():
                     '%s not in TOC, this block cannot be used!', name)
                 logconf.valid = False
                 raise KeyError('Variable {} not in TOC'.format(name))
-            # Now that we know what type this variable has, add it to the log
-            # config again with the correct type
-            logconf.add_variable(name, var.ctype)
+            resolved_default_variables.append(LogVariable(name, var.ctype))
 
         # Now check that all the added variables are in the TOC and that
         # the total size constraint of a data packet with logging data is
         # not
         size = 0
-        for var in logconf.variables:
+        effective_variables = logconf.variables + resolved_default_variables
+        for var in effective_variables:
             size += LogTocElement.get_size_from_id(var.fetch_as)
             # Check that we are able to find the variable in the TOC so
             # we can return error already now and not when the config is sent
@@ -495,12 +517,23 @@ class Log():
 
         if (size <= LogConfig.MAX_LEN and
                 (logconf.period > 0 and logconf.period < 0xFF)):
-            logconf.valid = True
-            logconf.cf = self.cf
-            logconf.id = self._config_id_counter
-            logconf.useV2 = self._useV2
-            self._config_id_counter = (self._config_id_counter + 1) % 255
-            self.log_blocks.append(logconf)
+            with self._registration_lock:
+                if logconf.id is not None or logconf.cf is not None:
+                    raise LogConfigError(
+                        'Log configuration is already registered')
+                if not self._ids_ready:
+                    raise LogConfigError(
+                        'Log configuration IDs are not ready')
+                if not self._available_config_ids:
+                    raise LogConfigError('No log configuration IDs available')
+                logconf.valid = True
+                logconf.cf = self.cf
+                logconf.id = self._available_config_ids.popleft()
+                logconf._delete_pending = False
+                logconf._resolved_default_variables = (
+                    resolved_default_variables)
+                logconf.useV2 = self._useV2
+                self.log_blocks.append(logconf)
             self.block_added_cb.call(logconf)
         else:
             logconf.valid = False
@@ -512,7 +545,6 @@ class Log():
         """
         Reset the log system and remove all log blocks
         """
-        self.log_blocks = []
         self._send_reset_packet()
 
     def refresh_toc(self, refresh_done_callback, toc_cache):
@@ -527,16 +559,100 @@ class Log():
         self._send_reset_packet()
 
     def _send_reset_packet(self):
+        with self._registration_lock:
+            if self._reset_pending:
+                return
+            self._reset_pending = True
+            self._ids_ready = False
+            self._available_config_ids.clear()
+
         pk = CRTPPacket()
         pk.set_header(CRTPPort.LOGGING, CHAN_SETTINGS)
         pk.data = (CMD_RESET_LOGGING,)
         self.cf.send_packet(pk, expected_reply=(CMD_RESET_LOGGING,))
 
+    def _detach_all_configs(self, restore_ids, require_reset_pending=False):
+        with self._registration_lock:
+            if require_reset_pending and not self._reset_pending:
+                return False
+            blocks = self.log_blocks
+            self.log_blocks = []
+            if restore_ids:
+                self._available_config_ids = deque(
+                    range(self.MAX_CONFIG_IDS))
+            else:
+                self._available_config_ids.clear()
+            self._ids_ready = restore_ids
+            self._reset_pending = False
+
+            callbacks = []
+            for block in blocks:
+                callbacks.append((block, block.started, block.added))
+                block._started = False
+                block._added = False
+                block._delete_pending = False
+                block.pending = False
+                block.id = None
+                block.cf = None
+                block._resolved_default_variables = []
+
+        for block, was_started, was_added in callbacks:
+            if was_started:
+                block.started_cb.call(block, False)
+            if was_added:
+                block.added_cb.call(block, False)
+        return True
+
+    def _disconnected(self, uri):
+        self._detach_all_configs(restore_ids=False)
+
     def _find_block(self, id):
-        for block in self.log_blocks:
-            if block.id == id:
-                return block
+        with self._registration_lock:
+            for block in self.log_blocks:
+                if block.id == id:
+                    return block
         return None
+
+    def _retire_config(self, logconf, block_id):
+        with self._registration_lock:
+            if (logconf not in self.log_blocks or
+                    logconf.id != block_id or
+                    not logconf._delete_pending):
+                return False
+
+            was_started = logconf.started
+            was_added = logconf.added
+            self.log_blocks.remove(logconf)
+            self._available_config_ids.append(block_id)
+            logconf._started = False
+            logconf._added = False
+            logconf._delete_pending = False
+            logconf.pending = False
+            logconf.id = None
+            logconf.cf = None
+            logconf._resolved_default_variables = []
+
+        if was_started:
+            logconf.started_cb.call(logconf, False)
+        if was_added:
+            logconf.added_cb.call(logconf, False)
+        return True
+
+    def _delete_config(self, logconf):
+        with self._registration_lock:
+            if logconf not in self.log_blocks or logconf.id is None:
+                return
+            if logconf._delete_pending:
+                return
+            logconf._delete_pending = True
+            block_id = logconf.id
+
+        logger.debug('LogEntry: Sending delete logging for block id=%d',
+                     block_id)
+        pk = CRTPPacket()
+        pk.set_header(CRTPPort.LOGGING, CHAN_SETTINGS)
+        pk.data = (CMD_DELETE_BLOCK, block_id)
+        self.cf.send_packet(pk, expected_reply=(CMD_DELETE_BLOCK, block_id))
 
     def _new_packet_cb(self, packet):
         """Callback for newly arrived packets with TOC information"""
@@ -604,15 +720,27 @@ class Log():
                 if error_status == 0x00 or error_status == errno.ENOENT:
                     logger.info('Have successfully deleted id=%d', id)
                     if block:
-                        block.started = False
-                        block.added = False
+                        self._retire_config(block, id)
+                elif block:
+                    with self._registration_lock:
+                        if block.id != id or not block._delete_pending:
+                            return
+                        block._delete_pending = False
+                        block.err_no = error_status
+                    msg = self._err_codes[error_status]
+                    block.error_cb.call(block, msg)
 
             if (cmd == CMD_RESET_LOGGING):
+                if error_status != 0x00:
+                    return
+
+                reset_completed = self._detach_all_configs(
+                    restore_ids=True, require_reset_pending=True)
+                if not reset_completed:
+                    return
                 # Guard against multiple responses due to re-sending
                 if not self.toc:
                     logger.debug('Logging reset, continue with TOC download')
-                    self.log_blocks = []
-
                     self.toc = Toc()
                     toc_fetcher = TocFetcher(self.cf, LogTocElement,
                                              CRTPPort.LOGGING,

--- a/cflib/crazyflie/log.py
+++ b/cflib/crazyflie/log.py
@@ -298,7 +298,9 @@ class LogConfig(object):
 
         num_variables = 0
         pending = 0
-        for block in cf.log.log_blocks:
+        with cf.log._registration_lock:
+            log_blocks = list(cf.log.log_blocks)
+        for block in log_blocks:
             if block.pending or block.added or block.started:
                 pending += 1
                 num_variables += len(block._get_effective_variables())

--- a/cflib/crazyflie/log.py
+++ b/cflib/crazyflie/log.py
@@ -327,9 +327,9 @@ class LogConfig(object):
 
             logger.debug('Adding/appending log block id {}'.format(block_id))
             cf.send_packet(pk, expected_reply=(command, block_id))
-            if self.cf is not cf or self.id != block_id:
+            if not cf.log._is_current_registration(self, cf, block_id):
                 raise LogConfigError(
-                    'Log configuration was detached while being created')
+                    'Log configuration changed while being created')
 
             # Use append if we have to add more variables
             command = self._cmd_append_block()
@@ -652,15 +652,20 @@ class Log():
     @contextmanager
     def _config_command(self, logconf, required=True):
         with self._command_lock:
-            with self._registration_lock:
-                registered = (self._ids_ready and
-                              logconf in self.log_blocks and
-                              logconf.cf is self.cf and
-                              logconf.id is not None and
-                              not logconf._delete_pending)
+            registered = self._is_current_registration(
+                logconf, self.cf, logconf.id)
             if required and not registered:
                 raise LogConfigError('Log configuration is not registered')
             yield registered
+
+    def _is_current_registration(self, logconf, cf, block_id):
+        with self._registration_lock:
+            return (self._ids_ready and
+                    logconf in self.log_blocks and
+                    logconf.cf is cf and
+                    logconf.id == block_id and
+                    block_id is not None and
+                    not logconf._delete_pending)
 
     def _retire_config(self, logconf, block_id):
         with self._registration_lock:

--- a/cflib/crazyflie/log.py
+++ b/cflib/crazyflie/log.py
@@ -55,6 +55,7 @@ import struct
 from collections import deque
 from contextlib import contextmanager
 from threading import Lock
+from threading import RLock
 
 from .toc import Toc
 from .toc import TocFetcher
@@ -289,13 +290,15 @@ class LogConfig(object):
             self._create()
 
     def _create(self):
+        cf = self.cf
+        block_id = self.id
         command = self._cmd_create_block()
         next_to_add = 0
         is_done = False
 
         num_variables = 0
         pending = 0
-        for block in self.cf.log.log_blocks:
+        for block in cf.log.log_blocks:
             if block.pending or block.added or block.started:
                 pending += 1
                 num_variables += len(block._get_effective_variables())
@@ -319,11 +322,14 @@ class LogConfig(object):
         while not is_done:
             pk = CRTPPacket()
             pk.set_header(5, CHAN_SETTINGS)
-            pk.data = (command, self.id)
+            pk.data = (command, block_id)
             is_done, next_to_add = self._setup_log_elements(pk, next_to_add)
 
-            logger.debug('Adding/appending log block id {}'.format(self.id))
-            self.cf.send_packet(pk, expected_reply=(command, self.id))
+            logger.debug('Adding/appending log block id {}'.format(block_id))
+            cf.send_packet(pk, expected_reply=(command, block_id))
+            if self.cf is not cf or self.id != block_id:
+                raise LogConfigError(
+                    'Log configuration was detached while being created')
 
             # Use append if we have to add more variables
             command = self._cmd_append_block()
@@ -488,7 +494,7 @@ class Log():
         self._toc_cache = None
 
         self._registration_lock = Lock()
-        self._command_lock = Lock()
+        self._command_lock = RLock()
         self._available_config_ids = deque()
         self._ids_ready = False
         self._reset_pending = False

--- a/cflib/crazyflie/log.py
+++ b/cflib/crazyflie/log.py
@@ -601,6 +601,8 @@ class Log():
             with self._registration_lock:
                 if self._reset_pending:
                     return
+                ids_were_ready = self._ids_ready
+                available_config_ids = self._available_config_ids.copy()
                 self._reset_pending = True
                 self._ids_ready = False
                 self._available_config_ids.clear()
@@ -613,7 +615,10 @@ class Log():
                     pk, expected_reply=(CMD_RESET_LOGGING,))
             except Exception:
                 with self._registration_lock:
-                    self._reset_pending = False
+                    if self._reset_pending:
+                        self._reset_pending = False
+                        self._ids_ready = ids_were_ready
+                        self._available_config_ids = available_config_ids
                 raise
 
     def _detach_all_configs(self, restore_ids, require_reset_pending=False):

--- a/cflib/crazyflie/log.py
+++ b/cflib/crazyflie/log.py
@@ -321,21 +321,30 @@ class LogConfig(object):
             raise AttributeError(
                 'Configuration has max number of blocks (%d)' % Log.MAX_BLOCKS
             )
-        self.pending += 1
-        while not is_done:
-            pk = CRTPPacket()
-            pk.set_header(5, CHAN_SETTINGS)
-            pk.data = (command, block_id)
-            is_done, next_to_add = self._setup_log_elements(pk, next_to_add)
+        self.pending = True
+        create_was_sent = False
+        try:
+            while not is_done:
+                pk = CRTPPacket()
+                pk.set_header(5, CHAN_SETTINGS)
+                pk.data = (command, block_id)
+                is_done, next_to_add = self._setup_log_elements(
+                    pk, next_to_add)
 
-            logger.debug('Adding/appending log block id {}'.format(block_id))
-            cf.send_packet(pk, expected_reply=(command, block_id))
-            if not cf.log._is_current_registration(self, cf, block_id):
-                raise LogConfigError(
-                    'Log configuration changed while being created')
+                logger.debug(
+                    'Adding/appending log block id {}'.format(block_id))
+                cf.send_packet(pk, expected_reply=(command, block_id))
+                create_was_sent = True
+                if not cf.log._is_current_registration(self, cf, block_id):
+                    raise LogConfigError(
+                        'Log configuration changed while being created')
 
-            # Use append if we have to add more variables
-            command = self._cmd_append_block()
+                # Use append if we have to add more variables
+                command = self._cmd_append_block()
+        except Exception:
+            if not create_was_sent:
+                self.pending = False
+            raise
 
     def start(self):
         """Start the logging for this entry"""
@@ -850,7 +859,8 @@ class Log():
                         logger.warning('Error %d when adding id=%d (%s)',
                                        error_status, id, msg)
                         block.err_no = error_status
-                        callbacks.append((block.added_cb, (False,)))
+                        block.pending = False
+                        callbacks.append((block.added_cb, (block, False)))
                         callbacks.append((block.error_cb, (block, msg)))
 
                 else:
@@ -873,7 +883,7 @@ class Log():
                     if (block is not None and self._is_current_registration(
                             block, self.cf, id)):
                         block.err_no = error_status
-                        callbacks.append((block.started_cb, (self, False)))
+                        callbacks.append((block.started_cb, (block, False)))
                         # This is a temporary fix, we are adding a new issue
                         # for this. For some reason we get an error back after
                         # the block has been started and added. This will show

--- a/cflib/crazyflie/log.py
+++ b/cflib/crazyflie/log.py
@@ -219,17 +219,25 @@ class LogConfig(object):
                                           stored_as, address))
 
     def _set_added(self, added):
-        if added != self._added:
+        if self._set_added_state(added):
             self.added_cb.call(self, added)
+
+    def _set_added_state(self, added):
+        changed = added != self._added
         self._added = added
+        return changed
 
     def _get_added(self):
         return self._added
 
     def _set_started(self, started):
-        if started != self._started:
+        if self._set_started_state(started):
             self.started_cb.call(self, started)
+
+    def _set_started_state(self, started):
+        changed = started != self._started
         self._started = started
+        return changed
 
     def _get_started(self):
         return self._started
@@ -296,14 +304,7 @@ class LogConfig(object):
         next_to_add = 0
         is_done = False
 
-        num_variables = 0
-        pending = 0
-        with cf.log._registration_lock:
-            log_blocks = list(cf.log.log_blocks)
-        for block in log_blocks:
-            if block.pending or block.added or block.started:
-                pending += 1
-                num_variables += len(block._get_effective_variables())
+        pending, num_variables = cf.log._get_active_config_usage()
 
         if pending < Log.MAX_BLOCKS:
             #
@@ -497,9 +498,13 @@ class Log():
 
         self._registration_lock = Lock()
         self._command_lock = RLock()
+        self._command_depth = 0
+        self._deferred_calls = deque()
+        self._dispatching_deferred_calls = False
         self._available_config_ids = deque()
         self._ids_ready = False
         self._reset_pending = False
+        self._ids_before_reset = None
 
         self._useV2 = False
 
@@ -513,6 +518,11 @@ class Log():
         cannot be used. Since a valid TOC is required, a Crazyflie has to be
         connected when calling this method, otherwise it will fail."""
 
+        with self._command_scope():
+            self._add_config(logconf)
+            self._defer_call(self.block_added_cb.call, logconf)
+
+    def _add_config(self, logconf):
         if not self.cf.link:
             raise LogConfigError(
                 'Cannot add log configurations without a connection')
@@ -524,13 +534,17 @@ class Log():
             if not self._ids_ready:
                 raise LogConfigError(
                     'Log configuration IDs are not ready')
+            toc = self.toc
+
+        if toc is None:
+            raise LogConfigError('Log TOC is not available')
 
         # If the log configuration contains variables that we added without
         # type (i.e we want the stored as type for fetching as well) then
         # resolve this now and add them to the block again.
         resolved_default_variables = []
         for name in logconf.default_fetch_as:
-            var = self.toc.get_element_by_complete_name(name)
+            var = toc.get_element_by_complete_name(name)
             if not var:
                 logger.warning(
                     '%s not in TOC, this block cannot be used!', name)
@@ -548,7 +562,7 @@ class Log():
             # Check that we are able to find the variable in the TOC so
             # we can return error already now and not when the config is sent
             if var.is_toc_variable():
-                if (self.toc.get_element_by_complete_name(var.name) is None):
+                if (toc.get_element_by_complete_name(var.name) is None):
                     logger.warning(
                         'Log: %s not in TOC, this block cannot be used!',
                         var.name)
@@ -574,7 +588,6 @@ class Log():
                     resolved_default_variables)
                 logconf.useV2 = self._useV2
                 self.log_blocks.append(logconf)
-            self.block_added_cb.call(logconf)
         else:
             logconf.valid = False
             raise AttributeError(
@@ -590,21 +603,22 @@ class Log():
     def refresh_toc(self, refresh_done_callback, toc_cache):
         """Start refreshing the table of loggale variables"""
 
-        self._useV2 = self.cf.platform.get_protocol_version() >= 4
+        with self._command_scope():
+            self._useV2 = self.cf.platform.get_protocol_version() >= 4
 
-        self._toc_cache = toc_cache
-        self._refresh_callback = refresh_done_callback
-        self.toc = None
+            self._toc_cache = toc_cache
+            self._refresh_callback = refresh_done_callback
+            self.toc = None
 
-        self._send_reset_packet()
+            self._send_reset_packet()
 
     def _send_reset_packet(self):
-        with self._command_lock:
+        with self._command_scope():
             with self._registration_lock:
                 if self._reset_pending:
                     return
-                ids_were_ready = self._ids_ready
-                available_config_ids = self._available_config_ids.copy()
+                self._ids_before_reset = (
+                    self._ids_ready, self._available_config_ids.copy())
                 self._reset_pending = True
                 self._ids_ready = False
                 self._available_config_ids.clear()
@@ -616,17 +630,24 @@ class Log():
                 self.cf.send_packet(
                     pk, expected_reply=(CMD_RESET_LOGGING,))
             except Exception:
-                with self._registration_lock:
-                    if self._reset_pending:
-                        self._reset_pending = False
-                        self._ids_ready = ids_were_ready
-                        self._available_config_ids = available_config_ids
+                self._restore_ids_after_failed_reset()
                 raise
+
+    def _restore_ids_after_failed_reset(self):
+        with self._registration_lock:
+            if not self._reset_pending:
+                return False
+            self._reset_pending = False
+            if self._ids_before_reset is not None:
+                self._ids_ready, self._available_config_ids = (
+                    self._ids_before_reset)
+            self._ids_before_reset = None
+        return True
 
     def _detach_all_configs(self, restore_ids, require_reset_pending=False):
         with self._registration_lock:
             if require_reset_pending and not self._reset_pending:
-                return False
+                return None
             blocks = self.log_blocks
             self.log_blocks = []
             if restore_ids:
@@ -636,18 +657,72 @@ class Log():
                 self._available_config_ids.clear()
             self._ids_ready = restore_ids
             self._reset_pending = False
+            self._ids_before_reset = None
 
             callbacks = []
             for block in blocks:
                 callbacks.append((block, block._detach()))
 
-        for block, previous_state in callbacks:
-            block._call_detached_callbacks(*previous_state)
-        return True
+        return callbacks
 
     def _disconnected(self, uri):
+        with self._command_scope():
+            callbacks = self._detach_all_configs(restore_ids=False)
+            self._defer_detached_callbacks(callbacks)
+
+    def _defer_detached_callbacks(self, callbacks):
+        for block, previous_state in callbacks:
+            self._defer_call(
+                block._call_detached_callbacks, *previous_state)
+
+    @contextmanager
+    def _command_scope(self):
+        should_dispatch = False
         with self._command_lock:
-            self._detach_all_configs(restore_ids=False)
+            self._command_depth += 1
+            try:
+                yield
+            finally:
+                self._command_depth -= 1
+                if (self._command_depth == 0 and
+                        self._deferred_calls and
+                        not self._dispatching_deferred_calls):
+                    self._dispatching_deferred_calls = True
+                    should_dispatch = True
+
+        if should_dispatch:
+            self._dispatch_deferred_calls()
+
+    def _defer_call(self, callback, *args):
+        self._deferred_calls.append((callback, args))
+
+    def _dispatch_deferred_calls(self):
+        first_error = None
+        while True:
+            with self._command_lock:
+                if not self._deferred_calls:
+                    self._dispatching_deferred_calls = False
+                    break
+                callback, args = self._deferred_calls.popleft()
+            try:
+                callback(*args)
+            except Exception as error:
+                if first_error is None:
+                    first_error = error
+
+        if first_error is not None:
+            raise first_error
+
+    def _get_active_config_usage(self):
+        with self._registration_lock:
+            log_blocks = list(self.log_blocks)
+
+        active_blocks = [
+            block for block in log_blocks
+            if block.pending or block.added or block.started]
+        variable_count = sum(
+            len(block._get_effective_variables()) for block in active_blocks)
+        return len(active_blocks), variable_count
 
     def _find_block(self, id):
         with self._registration_lock:
@@ -658,7 +733,7 @@ class Log():
 
     @contextmanager
     def _config_command(self, logconf, required=True):
-        with self._command_lock:
+        with self._command_scope():
             registered = self._is_current_registration(
                 logconf, self.cf, logconf.id)
             if required and not registered:
@@ -684,13 +759,16 @@ class Log():
             self.log_blocks.remove(logconf)
             if self._ids_ready:
                 self._available_config_ids.append(block_id)
+            elif self._reset_pending and self._ids_before_reset is not None:
+                ids_were_ready, available_config_ids = self._ids_before_reset
+                if ids_were_ready:
+                    available_config_ids.append(block_id)
             previous_state = logconf._detach()
 
-        logconf._call_detached_callbacks(*previous_state)
-        return True
+        return logconf, previous_state
 
     def _delete_config(self, logconf):
-        with self._command_lock:
+        with self._command_scope():
             with self._registration_lock:
                 if (not self._ids_ready or
                         logconf not in self.log_blocks or
@@ -723,95 +801,7 @@ class Log():
         payload = packet.data[1:]
 
         if (chan == CHAN_SETTINGS):
-            id = payload[0]
-            error_status = payload[1]
-            block = self._find_block(id)
-            if cmd == CMD_CREATE_BLOCK or cmd == CMD_CREATE_BLOCK_V2:
-                if (block is not None):
-                    if error_status == 0 or error_status == errno.EEXIST:
-                        if not block.added:
-                            logger.debug('Have successfully added id=%d', id)
-
-                            pk = CRTPPacket()
-                            pk.set_header(5, CHAN_SETTINGS)
-                            pk.data = (CMD_START_LOGGING, id, block.period)
-                            self.cf.send_packet(pk, expected_reply=(
-                                CMD_START_LOGGING, id))
-                            block.added = True
-                            block.pending = False
-                    else:
-                        msg = self._err_codes[error_status]
-                        logger.warning('Error %d when adding id=%d (%s)',
-                                       error_status, id, msg)
-                        block.err_no = error_status
-                        block.added_cb.call(False)
-                        block.error_cb.call(block, msg)
-
-                else:
-                    logger.warning('No LogEntry to assign block to !!!')
-            if (cmd == CMD_START_LOGGING):
-                if (error_status == 0x00):
-                    logger.info('Have successfully started logging for id=%d',
-                                id)
-                    if block:
-                        block.started = True
-
-                else:
-                    msg = self._err_codes[error_status]
-                    logger.warning('Error %d when starting id=%d (%s)',
-                                   error_status, id, msg)
-                    if block:
-                        block.err_no = error_status
-                        block.started_cb.call(self, False)
-                        # This is a temporary fix, we are adding a new issue
-                        # for this. For some reason we get an error back after
-                        # the block has been started and added. This will show
-                        # an error in the UI, but everything is still working.
-                        # block.error_cb.call(block, msg)
-
-            if (cmd == CMD_STOP_LOGGING):
-                if (error_status == 0x00):
-                    logger.info('Have successfully stopped logging for id=%d',
-                                id)
-                    if block:
-                        block.started = False
-
-            if (cmd == CMD_DELETE_BLOCK):
-                # Accept deletion of a block that isn't added. This could
-                # happen due to timing (i.e add/start/delete in fast sequence)
-                if error_status == 0x00 or error_status == errno.ENOENT:
-                    logger.info('Have successfully deleted id=%d', id)
-                    if block:
-                        self._retire_config(block, id)
-                elif block:
-                    with self._registration_lock:
-                        if block.id != id or not block._delete_pending:
-                            return
-                        block._delete_pending = False
-                        block.err_no = error_status
-                    msg = self._err_codes[error_status]
-                    block.error_cb.call(block, msg)
-
-            if (cmd == CMD_RESET_LOGGING):
-                if error_status != 0x00:
-                    with self._registration_lock:
-                        if self._reset_pending:
-                            self._reset_pending = False
-                    return
-
-                reset_completed = self._detach_all_configs(
-                    restore_ids=True, require_reset_pending=True)
-                if not reset_completed:
-                    return
-                # Guard against multiple responses due to re-sending
-                if not self.toc:
-                    logger.debug('Logging reset, continue with TOC download')
-                    self.toc = Toc()
-                    toc_fetcher = TocFetcher(self.cf, LogTocElement,
-                                             CRTPPort.LOGGING,
-                                             self.toc, self._refresh_callback,
-                                             self._toc_cache)
-                    toc_fetcher.start()
+            self._handle_settings_packet(cmd, payload)
 
         if (chan == CHAN_LOGDATA):
             chan = packet.channel
@@ -825,3 +815,120 @@ class Log():
                 block.unpack_log_data(logdata, timestamp)
             else:
                 logger.warning('Error no LogEntry to handle id=%d', id)
+
+    def _handle_settings_packet(self, cmd, payload):
+        callbacks = []
+        detached_callbacks = []
+        toc_fetcher = None
+
+        with self._command_scope():
+            id = payload[0]
+            error_status = payload[1]
+            block = self._find_block(id)
+
+            if cmd == CMD_CREATE_BLOCK or cmd == CMD_CREATE_BLOCK_V2:
+                if (block is not None and
+                        self._is_current_registration(block, self.cf, id)):
+                    if error_status == 0 or error_status == errno.EEXIST:
+                        if not block.added:
+                            logger.debug('Have successfully added id=%d', id)
+
+                            pk = CRTPPacket()
+                            pk.set_header(5, CHAN_SETTINGS)
+                            pk.data = (CMD_START_LOGGING, id, block.period)
+                            self.cf.send_packet(pk, expected_reply=(
+                                CMD_START_LOGGING, id))
+                            if not self._is_current_registration(
+                                    block, self.cf, id):
+                                return
+                            block.pending = False
+                            if block._set_added_state(True):
+                                callbacks.append(
+                                    (block.added_cb, (block, True)))
+                    else:
+                        msg = self._err_codes[error_status]
+                        logger.warning('Error %d when adding id=%d (%s)',
+                                       error_status, id, msg)
+                        block.err_no = error_status
+                        callbacks.append((block.added_cb, (False,)))
+                        callbacks.append((block.error_cb, (block, msg)))
+
+                else:
+                    logger.warning('No LogEntry to assign block to !!!')
+
+            if cmd == CMD_START_LOGGING:
+                if error_status == 0x00:
+                    logger.info(
+                        'Have successfully started logging for id=%d', id)
+                    if (block is not None and self._is_current_registration(
+                            block, self.cf, id)):
+                        if block._set_started_state(True):
+                            callbacks.append(
+                                (block.started_cb, (block, True)))
+
+                else:
+                    msg = self._err_codes[error_status]
+                    logger.warning('Error %d when starting id=%d (%s)',
+                                   error_status, id, msg)
+                    if (block is not None and self._is_current_registration(
+                            block, self.cf, id)):
+                        block.err_no = error_status
+                        callbacks.append((block.started_cb, (self, False)))
+                        # This is a temporary fix, we are adding a new issue
+                        # for this. For some reason we get an error back after
+                        # the block has been started and added. This will show
+                        # an error in the UI, but everything is still working.
+                        # block.error_cb.call(block, msg)
+
+            if cmd == CMD_STOP_LOGGING:
+                if error_status == 0x00:
+                    logger.info(
+                        'Have successfully stopped logging for id=%d', id)
+                    if (block is not None and self._is_current_registration(
+                            block, self.cf, id)):
+                        if block._set_started_state(False):
+                            callbacks.append(
+                                (block.started_cb, (block, False)))
+
+            if cmd == CMD_DELETE_BLOCK:
+                # Accept deletion of a block that isn't added. This could happen
+                # due to timing (i.e add/start/delete in fast sequence).
+                if error_status == 0x00 or error_status == errno.ENOENT:
+                    logger.info('Have successfully deleted id=%d', id)
+                    if block:
+                        retired_config = self._retire_config(block, id)
+                        if retired_config is not False:
+                            detached_callbacks.append(retired_config)
+                elif block:
+                    with self._registration_lock:
+                        if block.id != id or not block._delete_pending:
+                            return
+                        block._delete_pending = False
+                        block.err_no = error_status
+                    msg = self._err_codes[error_status]
+                    callbacks.append((block.error_cb, (block, msg)))
+
+            if cmd == CMD_RESET_LOGGING:
+                if error_status != 0x00:
+                    self._restore_ids_after_failed_reset()
+                    return
+
+                reset_callbacks = self._detach_all_configs(
+                    restore_ids=True, require_reset_pending=True)
+                if reset_callbacks is None:
+                    return
+                detached_callbacks.extend(reset_callbacks)
+                # Guard against multiple responses due to re-sending
+                if not self.toc:
+                    logger.debug(
+                        'Logging reset, continue with TOC download')
+                    self.toc = Toc()
+                    toc_fetcher = TocFetcher(
+                        self.cf, LogTocElement, CRTPPort.LOGGING,
+                        self.toc, self._refresh_callback, self._toc_cache)
+
+            for callback, args in callbacks:
+                self._defer_call(callback.call, *args)
+            self._defer_detached_callbacks(detached_callbacks)
+            if toc_fetcher is not None:
+                toc_fetcher.start()

--- a/cflib/crazyflie/log.py
+++ b/cflib/crazyflie/log.py
@@ -53,6 +53,7 @@ import errno
 import logging
 import struct
 from collections import deque
+from contextlib import contextmanager
 from threading import Lock
 
 from .toc import Toc
@@ -284,8 +285,7 @@ class LogConfig(object):
         if cf is None or self.id is None:
             raise LogConfigError(
                 'Log configuration must be added before it can be created')
-        with cf.log._command_lock:
-            cf.log._require_registered(self)
+        with cf.log._config_command(self):
             self._create()
 
     def _create(self):
@@ -334,8 +334,7 @@ class LogConfig(object):
         if cf is None or self.id is None:
             raise LogConfigError(
                 'Log configuration must be added before it can be started')
-        with cf.log._command_lock:
-            cf.log._require_registered(self)
+        with cf.log._config_command(self):
             if (cf.link is not None):
                 if (self._added is False):
                     self._create()
@@ -355,8 +354,8 @@ class LogConfig(object):
         cf = self.cf
         if cf is None or self.id is None:
             return
-        with cf.log._command_lock:
-            if not cf.log._is_registered(self):
+        with cf.log._config_command(self, required=False) as registered:
+            if not registered:
                 return
             block_id = self.id
             if (cf.link is not None):
@@ -634,7 +633,8 @@ class Log():
         return True
 
     def _disconnected(self, uri):
-        self._detach_all_configs(restore_ids=False)
+        with self._command_lock:
+            self._detach_all_configs(restore_ids=False)
 
     def _find_block(self, id):
         with self._registration_lock:
@@ -643,16 +643,18 @@ class Log():
                     return block
         return None
 
-    def _is_registered(self, logconf):
-        with self._registration_lock:
-            return (self._ids_ready and
-                    logconf in self.log_blocks and
-                    logconf.cf is self.cf and
-                    logconf.id is not None)
-
-    def _require_registered(self, logconf):
-        if not self._is_registered(logconf):
-            raise LogConfigError('Log configuration is not registered')
+    @contextmanager
+    def _config_command(self, logconf, required=True):
+        with self._command_lock:
+            with self._registration_lock:
+                registered = (self._ids_ready and
+                              logconf in self.log_blocks and
+                              logconf.cf is self.cf and
+                              logconf.id is not None and
+                              not logconf._delete_pending)
+            if required and not registered:
+                raise LogConfigError('Log configuration is not registered')
+            yield registered
 
     def _retire_config(self, logconf, block_id):
         with self._registration_lock:

--- a/cflib/crazyflie/log.py
+++ b/cflib/crazyflie/log.py
@@ -474,6 +474,7 @@ class Log():
         self._toc_cache = None
 
         self._registration_lock = Lock()
+        self._command_lock = Lock()
         self._available_config_ids = deque()
         self._ids_ready = False
         self._reset_pending = False
@@ -576,17 +577,24 @@ class Log():
         self._send_reset_packet()
 
     def _send_reset_packet(self):
-        with self._registration_lock:
-            if self._reset_pending:
-                return
-            self._reset_pending = True
-            self._ids_ready = False
-            self._available_config_ids.clear()
+        with self._command_lock:
+            with self._registration_lock:
+                if self._reset_pending:
+                    return
+                self._reset_pending = True
+                self._ids_ready = False
+                self._available_config_ids.clear()
 
-        pk = CRTPPacket()
-        pk.set_header(CRTPPort.LOGGING, CHAN_SETTINGS)
-        pk.data = (CMD_RESET_LOGGING,)
-        self.cf.send_packet(pk, expected_reply=(CMD_RESET_LOGGING,))
+            pk = CRTPPacket()
+            pk.set_header(CRTPPort.LOGGING, CHAN_SETTINGS)
+            pk.data = (CMD_RESET_LOGGING,)
+            try:
+                self.cf.send_packet(
+                    pk, expected_reply=(CMD_RESET_LOGGING,))
+            except Exception:
+                with self._registration_lock:
+                    self._reset_pending = False
+                raise
 
     def _detach_all_configs(self, restore_ids, require_reset_pending=False):
         with self._registration_lock:
@@ -636,28 +644,31 @@ class Log():
         return True
 
     def _delete_config(self, logconf):
-        with self._registration_lock:
-            if logconf not in self.log_blocks or logconf.id is None:
-                return
-            if logconf._delete_pending:
-                return
-            logconf._delete_pending = True
-            block_id = logconf.id
-
-        logger.debug('LogEntry: Sending delete logging for block id=%d',
-                     block_id)
-        pk = CRTPPacket()
-        pk.set_header(CRTPPort.LOGGING, CHAN_SETTINGS)
-        pk.data = (CMD_DELETE_BLOCK, block_id)
-        try:
-            self.cf.send_packet(
-                pk, expected_reply=(CMD_DELETE_BLOCK, block_id))
-        except Exception:
+        with self._command_lock:
             with self._registration_lock:
-                if (logconf.id == block_id and
-                        logconf._delete_pending):
-                    logconf._delete_pending = False
-            raise
+                if (not self._ids_ready or
+                        logconf not in self.log_blocks or
+                        logconf.id is None):
+                    return
+                if logconf._delete_pending:
+                    return
+                logconf._delete_pending = True
+                block_id = logconf.id
+
+            logger.debug('LogEntry: Sending delete logging for block id=%d',
+                         block_id)
+            pk = CRTPPacket()
+            pk.set_header(CRTPPort.LOGGING, CHAN_SETTINGS)
+            pk.data = (CMD_DELETE_BLOCK, block_id)
+            try:
+                self.cf.send_packet(
+                    pk, expected_reply=(CMD_DELETE_BLOCK, block_id))
+            except Exception:
+                with self._registration_lock:
+                    if (logconf.id == block_id and
+                            logconf._delete_pending):
+                        logconf._delete_pending = False
+                raise
 
     def _new_packet_cb(self, packet):
         """Callback for newly arrived packets with TOC information"""

--- a/test/crazyflie/test_log.py
+++ b/test/crazyflie/test_log.py
@@ -28,6 +28,7 @@ from unittest.mock import MagicMock
 
 from cflib.crazyflie import Crazyflie
 from cflib.crazyflie.log import CHAN_SETTINGS
+from cflib.crazyflie.log import CMD_CREATE_BLOCK
 from cflib.crazyflie.log import CMD_DELETE_BLOCK
 from cflib.crazyflie.log import CMD_RESET_LOGGING
 from cflib.crazyflie.log import Log
@@ -290,6 +291,44 @@ class LogTest(unittest.TestCase):
         self.log.reset()
 
         self.assertEqual(2, self.cf.send_packet.call_count)
+
+    def test_reset_waits_for_in_flight_start_command(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        self.log.toc = MagicMock()
+        self.log.toc.get_element_by_complete_name.return_value = MagicMock()
+        self.log.toc.get_element_id.return_value = 1
+        config = LogConfig('config', 100)
+        config.add_variable('group.value', 'uint8_t')
+        self.log.add_config(config)
+        create_send_started = threading.Event()
+        allow_create_send = threading.Event()
+        reset_finished = threading.Event()
+
+        def send_packet(packet, expected_reply):
+            if packet.data[0] == CMD_CREATE_BLOCK:
+                create_send_started.set()
+                allow_create_send.wait()
+
+        def reset():
+            self.log.reset()
+            reset_finished.set()
+
+        self.cf.send_packet.side_effect = send_packet
+        start_thread = threading.Thread(target=config.start)
+        start_thread.start()
+        self.assertTrue(create_send_started.wait(1.0))
+        reset_thread = threading.Thread(target=reset)
+        reset_thread.start()
+
+        try:
+            self.assertFalse(reset_finished.wait(0.1))
+        finally:
+            allow_create_send.set()
+            start_thread.join(1.0)
+            reset_thread.join(1.0)
+        self.assertFalse(start_thread.is_alive())
+        self.assertFalse(reset_thread.is_alive())
 
 
 if __name__ == '__main__':

--- a/test/crazyflie/test_log.py
+++ b/test/crazyflie/test_log.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+#
+#     ||          ____  _ __
+#  +------+      / __ )(_) /_______________ _____  ___
+#  | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+#  +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#   ||  ||    /_____/\___/\___/_/   \__,_/ /___/\___/
+#
+#  Copyright (C) 2026 Bitcraze AB
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+import errno
+import struct
+import unittest
+from unittest.mock import MagicMock
+
+from cflib.crazyflie import Crazyflie
+from cflib.crazyflie.log import CHAN_SETTINGS
+from cflib.crazyflie.log import CMD_DELETE_BLOCK
+from cflib.crazyflie.log import CMD_RESET_LOGGING
+from cflib.crazyflie.log import Log
+from cflib.crazyflie.log import LogConfig
+from cflib.crazyflie.log import LogConfigError
+from cflib.crazyflie.toc import Toc
+from cflib.crtp.crtpstack import CRTPPacket
+from cflib.crtp.crtpstack import CRTPPort
+from cflib.utils.callbacks import Caller
+
+
+class LogTest(unittest.TestCase):
+
+    def setUp(self):
+        self.cf = MagicMock(spec=Crazyflie)
+        self.cf.link = object()
+        self.cf.disconnected = Caller()
+        self.log = Log(self.cf)
+        self.cf.log = self.log
+        self.log.toc = Toc()
+
+    def _acknowledge(self, command, block_id=0, error_status=0):
+        packet = CRTPPacket()
+        packet.set_header(CRTPPort.LOGGING, CHAN_SETTINGS)
+        packet.data = (command, block_id, error_status)
+        self.log._new_packet_cb(packet)
+
+    def _make_config(self, name):
+        config = LogConfig(name, 100)
+        config.add_memory('value', 'uint8_t', 'uint8_t', 0x1000)
+        return config
+
+    def test_all_byte_values_are_available_as_log_config_ids(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+
+        configs = [self._make_config('config-{}'.format(i)) for i in range(256)]
+        for config in configs:
+            self.log.add_config(config)
+
+        self.assertEqual(list(range(256)), [config.id for config in configs])
+        with self.assertRaises(LogConfigError):
+            self.log.add_config(self._make_config('one-too-many'))
+
+    def test_deleted_id_is_released_after_acknowledgement(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        deleted_config = self._make_config('deleted')
+        self.log.add_config(deleted_config)
+        deleted_config.delete()
+        for i in range(1, 256):
+            self.log.add_config(self._make_config('config-{}'.format(i)))
+
+        with self.assertRaises(LogConfigError):
+            self.log.add_config(self._make_config('before-ack'))
+
+        self._acknowledge(CMD_DELETE_BLOCK, deleted_config.id)
+
+        self.assertIsNone(deleted_config.id)
+        self.assertIsNone(deleted_config.cf)
+        self.assertNotIn(deleted_config, self.log.log_blocks)
+        self.log.add_config(deleted_config)
+        self.assertEqual(0, deleted_config.id)
+
+    def test_delete_is_idempotent_until_a_failed_acknowledgement(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_config('config')
+        self.log.add_config(config)
+        self.cf.send_packet.reset_mock()
+
+        config.delete()
+        config.delete()
+
+        self.assertEqual(1, self.cf.send_packet.call_count)
+        self._acknowledge(CMD_DELETE_BLOCK, config.id, errno.ENOMEM)
+        self.assertEqual(0, config.id)
+        self.assertIn(config, self.log.log_blocks)
+
+        config.delete()
+        self.assertEqual(2, self.cf.send_packet.call_count)
+
+    def test_reset_acknowledgement_detaches_configs_and_restores_ids(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_config('old-config')
+        self.log.add_config(config)
+
+        self.log.reset()
+
+        self.assertEqual(0, config.id)
+        with self.assertRaises(LogConfigError):
+            self.log.add_config(self._make_config('during-reset'))
+
+        self._acknowledge(CMD_RESET_LOGGING)
+
+        self.assertIsNone(config.id)
+        self.assertIsNone(config.cf)
+        self.assertEqual([], self.log.log_blocks)
+        new_config = self._make_config('new-config')
+        self.log.add_config(new_config)
+        self.assertEqual(0, new_config.id)
+
+    def test_disconnect_detaches_configs_without_restoring_ids(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_config('config')
+        self.log.add_config(config)
+
+        self.cf.disconnected.call('radio://test')
+
+        self.assertIsNone(config.id)
+        self.assertIsNone(config.cf)
+        self.assertEqual([], self.log.log_blocks)
+        self.cf.link = None
+        with self.assertRaises(LogConfigError):
+            self.log.add_config(self._make_config('after-disconnect'))
+
+    def test_detached_config_requires_registration_before_start(self):
+        config = self._make_config('config')
+
+        config.stop()
+        config.delete()
+        with self.assertRaises(LogConfigError):
+            config.start()
+
+    def test_config_cannot_be_registered_twice(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_config('config')
+        self.log.add_config(config)
+
+        with self.assertRaises(LogConfigError):
+            self.log.add_config(config)
+
+        other_config = self._make_config('other-config')
+        self.log.add_config(other_config)
+        self.assertEqual(1, other_config.id)
+
+    def test_untyped_variables_are_resolved_fresh_when_reregistered(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        toc_element = MagicMock()
+        toc_element.ctype = 'uint8_t'
+        self.log.toc = MagicMock()
+        self.log.toc.get_element_by_complete_name.return_value = toc_element
+        config = LogConfig('config', 100)
+        config.add_variable('group.value')
+        self.log.add_config(config)
+        config.delete()
+        self._acknowledge(CMD_DELETE_BLOCK, config.id)
+
+        toc_element.ctype = 'uint16_t'
+        self.log.add_config(config)
+        received = []
+        config.data_received_cb.add_callback(
+            lambda timestamp, data, logconf: received.append(data))
+
+        config.unpack_log_data(struct.pack('<H', 513), 0)
+
+        self.assertEqual([{'group.value': 513}], received)
+
+    def test_delete_of_missing_firmware_block_releases_id(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_config('config')
+        self.log.add_config(config)
+        config.delete()
+
+        self._acknowledge(CMD_DELETE_BLOCK, config.id, errno.ENOENT)
+
+        self.assertIsNone(config.id)
+
+    def test_duplicate_reset_ack_does_not_detach_new_config(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_config('config')
+        self.log.add_config(config)
+
+        self._acknowledge(CMD_RESET_LOGGING)
+
+        self.assertEqual(0, config.id)
+        self.assertIn(config, self.log.log_blocks)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/crazyflie/test_log.py
+++ b/test/crazyflie/test_log.py
@@ -21,6 +21,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 import errno
 import struct
+import threading
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock
@@ -245,6 +246,50 @@ class LogTest(unittest.TestCase):
 
         self.assertEqual(list(range(256)), sorted(
             config.id for config in configs))
+
+    def test_reset_waits_for_in_flight_delete_command(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_config('config')
+        self.log.add_config(config)
+        delete_send_started = threading.Event()
+        allow_delete_send = threading.Event()
+        reset_finished = threading.Event()
+
+        def send_packet(packet, expected_reply):
+            if packet.data[0] == CMD_DELETE_BLOCK:
+                delete_send_started.set()
+                allow_delete_send.wait()
+
+        self.cf.send_packet.side_effect = send_packet
+        delete_thread = threading.Thread(target=config.delete)
+        delete_thread.start()
+        self.assertTrue(delete_send_started.wait(1.0))
+
+        def reset():
+            self.log.reset()
+            reset_finished.set()
+
+        reset_thread = threading.Thread(target=reset)
+        reset_thread.start()
+
+        try:
+            self.assertFalse(reset_finished.wait(0.1))
+        finally:
+            allow_delete_send.set()
+            delete_thread.join(1.0)
+            reset_thread.join(1.0)
+        self.assertFalse(delete_thread.is_alive())
+        self.assertFalse(reset_thread.is_alive())
+
+    def test_reset_can_be_retried_when_sending_fails(self):
+        self.cf.send_packet.side_effect = [RuntimeError('send failed'), None]
+
+        with self.assertRaises(RuntimeError):
+            self.log.reset()
+        self.log.reset()
+
+        self.assertEqual(2, self.cf.send_packet.call_count)
 
 
 if __name__ == '__main__':

--- a/test/crazyflie/test_log.py
+++ b/test/crazyflie/test_log.py
@@ -304,6 +304,22 @@ class LogTest(unittest.TestCase):
 
         self.assertEqual(2, self.cf.send_packet.call_count)
 
+    def test_failed_reset_send_restores_config_id_state(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_config('config')
+        self.log.add_config(config)
+        self.cf.send_packet.side_effect = RuntimeError('send failed')
+
+        with self.assertRaises(RuntimeError):
+            self.log.reset()
+
+        self.assertTrue(self.log._is_current_registration(
+            config, self.cf, config.id))
+        other_config = self._make_config('other-config')
+        self.log.add_config(other_config)
+        self.assertEqual(1, other_config.id)
+
     def test_reset_waits_for_in_flight_start_command(self):
         self.log.reset()
         self._acknowledge(CMD_RESET_LOGGING)

--- a/test/crazyflie/test_log.py
+++ b/test/crazyflie/test_log.py
@@ -330,6 +330,57 @@ class LogTest(unittest.TestCase):
         self.assertFalse(start_thread.is_alive())
         self.assertFalse(reset_thread.is_alive())
 
+    def test_start_is_rejected_while_delete_is_pending(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_config('config')
+        self.log.add_config(config)
+        config.delete()
+
+        with self.assertRaises(LogConfigError):
+            config.start()
+
+        self.assertEqual(2, self.cf.send_packet.call_count)
+
+    def test_disconnect_waits_for_in_flight_start_command(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        self.log.toc = MagicMock()
+        self.log.toc.get_element_by_complete_name.return_value = MagicMock()
+        self.log.toc.get_element_id.return_value = 1
+        config = LogConfig('config', 100)
+        config.add_variable('group.value', 'uint8_t')
+        self.log.add_config(config)
+        create_send_started = threading.Event()
+        allow_create_send = threading.Event()
+        disconnect_finished = threading.Event()
+
+        def send_packet(packet, expected_reply):
+            if packet.data[0] == CMD_CREATE_BLOCK:
+                create_send_started.set()
+                allow_create_send.wait()
+
+        def disconnect():
+            self.cf.disconnected.call('radio://test')
+            disconnect_finished.set()
+
+        self.cf.send_packet.side_effect = send_packet
+        start_thread = threading.Thread(target=config.start)
+        start_thread.start()
+        self.assertTrue(create_send_started.wait(1.0))
+        disconnect_thread = threading.Thread(target=disconnect)
+        disconnect_thread.start()
+
+        try:
+            self.assertFalse(disconnect_finished.wait(0.1))
+        finally:
+            allow_create_send.set()
+            start_thread.join(1.0)
+            disconnect_thread.join(1.0)
+        self.assertFalse(start_thread.is_alive())
+        self.assertFalse(disconnect_thread.is_alive())
+        self.assertIsNone(config.id)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/crazyflie/test_log.py
+++ b/test/crazyflie/test_log.py
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock
 from cflib.crazyflie import Crazyflie
 from cflib.crazyflie.log import CHAN_SETTINGS
 from cflib.crazyflie.log import CMD_CREATE_BLOCK
+from cflib.crazyflie.log import CMD_CREATE_BLOCK_V2
 from cflib.crazyflie.log import CMD_DELETE_BLOCK
 from cflib.crazyflie.log import CMD_RESET_LOGGING
 from cflib.crazyflie.log import Log
@@ -59,6 +60,17 @@ class LogTest(unittest.TestCase):
     def _make_config(self, name):
         config = LogConfig(name, 100)
         config.add_memory('value', 'uint8_t', 'uint8_t', 0x1000)
+        return config
+
+    def _make_multi_packet_config(self):
+        self.log._useV2 = True
+        self.log.toc = MagicMock()
+        self.log.toc.get_element_by_complete_name.return_value = MagicMock()
+        self.log.toc.get_element_id.return_value = 1
+        config = LogConfig('multi-packet', 100)
+        for i in range(20):
+            config.add_variable('group.value{}'.format(i), 'uint8_t')
+        self.log.add_config(config)
         return config
 
     def test_all_byte_values_are_available_as_log_config_ids(self):
@@ -409,6 +421,44 @@ class LogTest(unittest.TestCase):
         self.assertFalse(start_thread.is_alive())
         self.assertEqual(1, len(errors))
         self.assertIsNone(config.id)
+
+    def test_synchronous_reset_during_create_prevents_append(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_multi_packet_config()
+        sent_commands = []
+
+        def send_packet(packet, expected_reply):
+            sent_commands.append(packet.data[0])
+            if packet.data[0] == CMD_CREATE_BLOCK_V2:
+                self.log.reset()
+
+        self.cf.send_packet.side_effect = send_packet
+
+        with self.assertRaises(LogConfigError):
+            config.start()
+
+        self.assertEqual(
+            [CMD_CREATE_BLOCK_V2, CMD_RESET_LOGGING], sent_commands)
+
+    def test_synchronous_delete_during_create_prevents_append(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_multi_packet_config()
+        sent_commands = []
+
+        def send_packet(packet, expected_reply):
+            sent_commands.append(packet.data[0])
+            if packet.data[0] == CMD_CREATE_BLOCK_V2:
+                config.delete()
+
+        self.cf.send_packet.side_effect = send_packet
+
+        with self.assertRaises(LogConfigError):
+            config.start()
+
+        self.assertEqual(
+            [CMD_CREATE_BLOCK_V2, CMD_DELETE_BLOCK], sent_commands)
 
 
 if __name__ == '__main__':

--- a/test/crazyflie/test_log.py
+++ b/test/crazyflie/test_log.py
@@ -310,6 +310,57 @@ class LogTest(unittest.TestCase):
 
         self.assertEqual(2, self.cf.send_packet.call_count)
 
+    def test_create_send_failure_clears_pending_state(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_toc_config('config')
+        self.log.add_config(config)
+        self.cf.send_packet.side_effect = RuntimeError('send failed')
+
+        with self.assertRaisesRegex(RuntimeError, 'send failed'):
+            config.create()
+
+        self.assertFalse(config.pending)
+        self.assertEqual((0, 0), self.log._get_active_config_usage())
+
+    def test_create_error_clears_pending_and_reports_config(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_toc_config('config')
+        self.log.add_config(config)
+        added_events = []
+        error_events = []
+        config.added_cb.add_callback(
+            lambda logconf, added: added_events.append((logconf, added)))
+        config.error_cb.add_callback(
+            lambda logconf, message: error_events.append((logconf, message)))
+
+        config.create()
+        self.assertIs(config.pending, True)
+        self._acknowledge(CMD_CREATE_BLOCK, config.id, errno.ENOMEM)
+
+        self.assertFalse(config.pending)
+        self.assertEqual([(config, False)], added_events)
+        self.assertEqual(
+            [(config, 'No more memory available')], error_events)
+        self.assertEqual((0, 0), self.log._get_active_config_usage())
+
+    def test_start_error_reports_config(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_toc_config('config')
+        self.log.add_config(config)
+        started_events = []
+        config.started_cb.add_callback(
+            lambda logconf, started:
+            started_events.append((logconf, started)))
+
+        config.create()
+        self._acknowledge(CMD_CREATE_BLOCK, config.id)
+        self._acknowledge(CMD_START_LOGGING, config.id, errno.ENOEXEC)
+
+        self.assertEqual([(config, False)], started_events)
+
     def test_reset_can_be_retried_after_failed_acknowledgement(self):
         self.log.reset()
         self._acknowledge(CMD_RESET_LOGGING)

--- a/test/crazyflie/test_log.py
+++ b/test/crazyflie/test_log.py
@@ -476,6 +476,35 @@ class LogTest(unittest.TestCase):
         self.assertEqual(
             [CMD_CREATE_BLOCK_V2, CMD_DELETE_BLOCK], sent_commands)
 
+    def test_create_counts_from_stable_registration_snapshot(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        existing_config = self._make_config('existing-config')
+        self.log.add_config(existing_config)
+        existing_config.pending = True
+        existing_config.variables *= Log.MAX_VARIABLES
+        config = self._make_config('config')
+        self.log.add_config(config)
+
+        class RemovingBlock:
+            pending = False
+            added = False
+            started = False
+
+            def __init__(self, log):
+                self.log = log
+
+            def _get_effective_variables(self):
+                self.log.log_blocks.remove(self)
+                return []
+
+        removing_block = RemovingBlock(self.log)
+        removing_block.pending = True
+        self.log.log_blocks.insert(0, removing_block)
+
+        with self.assertRaises(AttributeError):
+            config.create()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/crazyflie/test_log.py
+++ b/test/crazyflie/test_log.py
@@ -27,11 +27,14 @@ from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock
 
 from cflib.crazyflie import Crazyflie
+from cflib.crazyflie.log import CHAN_LOGDATA
 from cflib.crazyflie.log import CHAN_SETTINGS
 from cflib.crazyflie.log import CMD_CREATE_BLOCK
 from cflib.crazyflie.log import CMD_CREATE_BLOCK_V2
 from cflib.crazyflie.log import CMD_DELETE_BLOCK
 from cflib.crazyflie.log import CMD_RESET_LOGGING
+from cflib.crazyflie.log import CMD_START_LOGGING
+from cflib.crazyflie.log import CMD_STOP_LOGGING
 from cflib.crazyflie.log import Log
 from cflib.crazyflie.log import LogConfig
 from cflib.crazyflie.log import LogConfigError
@@ -62,6 +65,14 @@ class LogTest(unittest.TestCase):
         config.add_memory('value', 'uint8_t', 'uint8_t', 0x1000)
         return config
 
+    def _make_toc_config(self, name):
+        self.log.toc = MagicMock()
+        self.log.toc.get_element_by_complete_name.return_value = MagicMock()
+        self.log.toc.get_element_id.return_value = 1
+        config = LogConfig(name, 100)
+        config.add_variable('group.value', 'uint8_t')
+        return config
+
     def _make_multi_packet_config(self):
         self.log._useV2 = True
         self.log.toc = MagicMock()
@@ -72,6 +83,10 @@ class LogTest(unittest.TestCase):
             config.add_variable('group.value{}'.format(i), 'uint8_t')
         self.log.add_config(config)
         return config
+
+    def _add_thread_cleanup(self, thread, unblock_event):
+        self.addCleanup(thread.join, 1.0)
+        self.addCleanup(unblock_event.set)
 
     def test_all_byte_values_are_available_as_log_config_ids(self):
         self.log.reset()
@@ -104,6 +119,34 @@ class LogTest(unittest.TestCase):
         self.assertNotIn(deleted_config, self.log.log_blocks)
         self.log.add_config(deleted_config)
         self.assertEqual(0, deleted_config.id)
+
+    def test_300_create_start_stop_delete_cycles(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+
+        for i in range(300):
+            config = self._make_toc_config('config-{}'.format(i))
+            self.log.add_config(config)
+            received = []
+            config.data_received_cb.add_callback(
+                lambda timestamp, data, logconf: received.append(data))
+            config.start()
+            self._acknowledge(CMD_CREATE_BLOCK, config.id)
+            self._acknowledge(CMD_START_LOGGING, config.id)
+
+            packet = CRTPPacket()
+            packet.set_header(CRTPPort.LOGGING, CHAN_LOGDATA)
+            packet.data = (config.id, 0, 0, 0, i % 256)
+            self.log._new_packet_cb(packet)
+
+            config.stop()
+            self._acknowledge(CMD_STOP_LOGGING, config.id)
+            config.delete()
+            self._acknowledge(CMD_DELETE_BLOCK, config.id)
+
+            self.assertEqual([{'group.value': i % 256}], received)
+            self.assertIsNone(config.id)
+            self.assertEqual([], self.log.log_blocks)
 
     def test_delete_is_idempotent_until_a_failed_acknowledgement(self):
         self.log.reset()
@@ -203,6 +246,34 @@ class LogTest(unittest.TestCase):
 
         self.assertEqual([{'group.value': 513}], received)
 
+    def test_refresh_during_untyped_validation_fails_cleanly(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        toc = MagicMock()
+        toc_element = MagicMock()
+        toc_element.ctype = 'uint8_t'
+        refresh_started = False
+
+        def get_element(name):
+            nonlocal refresh_started
+            if not refresh_started:
+                refresh_started = True
+                self.cf.platform = MagicMock()
+                self.cf.platform.get_protocol_version.return_value = 4
+                self.log.refresh_toc(None, None)
+            return toc_element
+
+        toc.get_element_by_complete_name.side_effect = get_element
+        self.log.toc = toc
+        config = LogConfig('config', 100)
+        config.add_variable('group.value')
+
+        with self.assertRaises(LogConfigError):
+            self.log.add_config(config)
+
+        self.assertIsNone(config.id)
+        self.assertIsNone(config.cf)
+
     def test_delete_of_missing_firmware_block_releases_id(self):
         self.log.reset()
         self._acknowledge(CMD_RESET_LOGGING)
@@ -241,12 +312,43 @@ class LogTest(unittest.TestCase):
 
     def test_reset_can_be_retried_after_failed_acknowledgement(self):
         self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_config('config')
+        self.log.add_config(config)
+
+        self.log.reset()
         self._acknowledge(CMD_RESET_LOGGING, error_status=errno.ENOEXEC)
         self.cf.send_packet.reset_mock()
+
+        self.assertTrue(self.log._is_current_registration(
+            config, self.cf, config.id))
+        other_config = self._make_config('other-config')
+        self.log.add_config(other_config)
+        self.assertEqual(1, other_config.id)
 
         self.log.reset()
 
         self.assertEqual(1, self.cf.send_packet.call_count)
+
+    def test_delete_ack_during_failed_reset_releases_id(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_config('config')
+        self.log.add_config(config)
+        config.delete()
+        block_id = config.id
+        self.log.reset()
+
+        self._acknowledge(CMD_DELETE_BLOCK, block_id)
+        self._acknowledge(CMD_RESET_LOGGING, error_status=errno.ENOEXEC)
+
+        self.assertIsNone(config.id)
+        configs = [self._make_config('config-{}'.format(i))
+                   for i in range(Log.MAX_CONFIG_IDS)]
+        for new_config in configs:
+            self.log.add_config(new_config)
+        self.assertEqual(set(range(Log.MAX_CONFIG_IDS)), {
+            new_config.id for new_config in configs})
 
     def test_ids_are_unique_when_configs_are_registered_concurrently(self):
         self.log.reset()
@@ -277,6 +379,7 @@ class LogTest(unittest.TestCase):
         self.cf.send_packet.side_effect = send_packet
         delete_thread = threading.Thread(target=config.delete)
         delete_thread.start()
+        self._add_thread_cleanup(delete_thread, allow_delete_send)
         self.assertTrue(delete_send_started.wait(1.0))
 
         def reset():
@@ -285,6 +388,7 @@ class LogTest(unittest.TestCase):
 
         reset_thread = threading.Thread(target=reset)
         reset_thread.start()
+        self._add_thread_cleanup(reset_thread, allow_delete_send)
 
         try:
             self.assertFalse(reset_finished.wait(0.1))
@@ -345,9 +449,11 @@ class LogTest(unittest.TestCase):
         self.cf.send_packet.side_effect = send_packet
         start_thread = threading.Thread(target=config.start)
         start_thread.start()
+        self._add_thread_cleanup(start_thread, allow_create_send)
         self.assertTrue(create_send_started.wait(1.0))
         reset_thread = threading.Thread(target=reset)
         reset_thread.start()
+        self._add_thread_cleanup(reset_thread, allow_create_send)
 
         try:
             self.assertFalse(reset_finished.wait(0.1))
@@ -357,6 +463,63 @@ class LogTest(unittest.TestCase):
             reset_thread.join(1.0)
         self.assertFalse(start_thread.is_alive())
         self.assertFalse(reset_thread.is_alive())
+
+    def test_reset_waits_for_create_acknowledgement_follow_up(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_toc_config('config')
+        self.log.add_config(config)
+        config.start()
+        start_send_started = threading.Event()
+        allow_start_send = threading.Event()
+        reset_finished = threading.Event()
+
+        def send_packet(packet, expected_reply):
+            if packet.data[0] == CMD_START_LOGGING:
+                start_send_started.set()
+                allow_start_send.wait()
+
+        def acknowledge_create():
+            self._acknowledge(CMD_CREATE_BLOCK, config.id)
+
+        def reset():
+            self.log.reset()
+            reset_finished.set()
+
+        self.cf.send_packet.side_effect = send_packet
+        acknowledge_thread = threading.Thread(target=acknowledge_create)
+        acknowledge_thread.start()
+        self._add_thread_cleanup(acknowledge_thread, allow_start_send)
+        self.assertTrue(start_send_started.wait(1.0))
+        reset_thread = threading.Thread(target=reset)
+        reset_thread.start()
+        self._add_thread_cleanup(reset_thread, allow_start_send)
+
+        try:
+            self.assertFalse(reset_finished.wait(0.1))
+        finally:
+            allow_start_send.set()
+            acknowledge_thread.join(1.0)
+            reset_thread.join(1.0)
+        self.assertFalse(acknowledge_thread.is_alive())
+        self.assertFalse(reset_thread.is_alive())
+
+    def test_create_acknowledgement_is_ignored_during_reset(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_toc_config('config')
+        self.log.add_config(config)
+        self.cf.send_packet.reset_mock()
+        config.start()
+        self.log.reset()
+
+        self._acknowledge(CMD_CREATE_BLOCK, config.id)
+
+        self.assertEqual(
+            [CMD_CREATE_BLOCK, CMD_RESET_LOGGING],
+            [call.args[0].data[0]
+             for call in self.cf.send_packet.call_args_list])
+        self.assertFalse(config.added)
 
     def test_start_is_rejected_while_delete_is_pending(self):
         self.log.reset()
@@ -395,9 +558,11 @@ class LogTest(unittest.TestCase):
         self.cf.send_packet.side_effect = send_packet
         start_thread = threading.Thread(target=config.start)
         start_thread.start()
+        self._add_thread_cleanup(start_thread, allow_create_send)
         self.assertTrue(create_send_started.wait(1.0))
         disconnect_thread = threading.Thread(target=disconnect)
         disconnect_thread.start()
+        self._add_thread_cleanup(disconnect_thread, allow_create_send)
 
         try:
             self.assertFalse(disconnect_finished.wait(0.1))
@@ -438,6 +603,101 @@ class LogTest(unittest.TestCase):
         self.assertEqual(1, len(errors))
         self.assertIsNone(config.id)
 
+    def test_disconnect_during_create_acknowledgement_does_not_revive_config(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_toc_config('config')
+        self.log.add_config(config)
+        config.start()
+
+        def send_packet(packet, expected_reply):
+            if packet.data[0] == CMD_START_LOGGING:
+                self.cf.disconnected.call('radio://test')
+
+        self.cf.send_packet.side_effect = send_packet
+
+        self._acknowledge(CMD_CREATE_BLOCK, config.id)
+
+        self.assertIsNone(config.id)
+        self.assertFalse(config.added)
+
+    def test_added_callback_cannot_revive_disconnected_config(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_toc_config('config')
+        self.log.add_config(config)
+        config.start()
+        added_states = []
+
+        def added_callback(log_config, added):
+            added_states.append(added)
+            if added:
+                self.cf.disconnected.call('radio://test')
+
+        config.added_cb.add_callback(added_callback)
+
+        self._acknowledge(CMD_CREATE_BLOCK, config.id)
+
+        self.assertEqual([True, False], added_states)
+        self.assertIsNone(config.id)
+        self.assertFalse(config.added)
+
+    def test_added_callbacks_are_ordered_without_holding_command_lock(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_toc_config('config')
+        self.log.add_config(config)
+        config.start()
+        added_states = []
+        states_before_callback_returns = []
+        disconnect_completed = []
+
+        def added_callback(log_config, added):
+            added_states.append(added)
+            if added:
+                disconnect_thread = threading.Thread(
+                    target=lambda: self.cf.disconnected.call('radio://test'))
+                disconnect_thread.start()
+                self.addCleanup(disconnect_thread.join, 1.0)
+                disconnect_thread.join(1.0)
+                disconnect_completed.append(
+                    not disconnect_thread.is_alive())
+                states_before_callback_returns.append(list(added_states))
+
+        config.added_cb.add_callback(added_callback)
+
+        self._acknowledge(CMD_CREATE_BLOCK, config.id)
+
+        self.assertEqual([True], disconnect_completed)
+        self.assertEqual([[True]], states_before_callback_returns)
+        self.assertEqual([True, False], added_states)
+
+    def test_callback_failure_does_not_strand_lifecycle_notifications(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_toc_config('config')
+        self.log.add_config(config)
+        config.start()
+        added_states = []
+
+        def added_callback(log_config, added):
+            added_states.append(added)
+            if added:
+                disconnect_thread = threading.Thread(
+                    target=lambda: self.cf.disconnected.call('radio://test'))
+                disconnect_thread.start()
+                self.addCleanup(disconnect_thread.join, 1.0)
+                disconnect_thread.join(1.0)
+                raise RuntimeError('callback failed')
+
+        config.added_cb.add_callback(added_callback)
+
+        with self.assertRaisesRegex(RuntimeError, 'callback failed'):
+            self._acknowledge(CMD_CREATE_BLOCK, config.id)
+
+        self.assertEqual([True, False], added_states)
+        self.assertIsNone(config.id)
+
     def test_synchronous_reset_during_create_prevents_append(self):
         self.log.reset()
         self._acknowledge(CMD_RESET_LOGGING)
@@ -475,35 +735,6 @@ class LogTest(unittest.TestCase):
 
         self.assertEqual(
             [CMD_CREATE_BLOCK_V2, CMD_DELETE_BLOCK], sent_commands)
-
-    def test_create_counts_from_stable_registration_snapshot(self):
-        self.log.reset()
-        self._acknowledge(CMD_RESET_LOGGING)
-        existing_config = self._make_config('existing-config')
-        self.log.add_config(existing_config)
-        existing_config.pending = True
-        existing_config.variables *= Log.MAX_VARIABLES
-        config = self._make_config('config')
-        self.log.add_config(config)
-
-        class RemovingBlock:
-            pending = False
-            added = False
-            started = False
-
-            def __init__(self, log):
-                self.log = log
-
-            def _get_effective_variables(self):
-                self.log.log_blocks.remove(self)
-                return []
-
-        removing_block = RemovingBlock(self.log)
-        removing_block.pending = True
-        self.log.log_blocks.insert(0, removing_block)
-
-        with self.assertRaises(AttributeError):
-            config.create()
 
 
 if __name__ == '__main__':

--- a/test/crazyflie/test_log.py
+++ b/test/crazyflie/test_log.py
@@ -22,6 +22,7 @@
 import errno
 import struct
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock
 
 from cflib.crazyflie import Crazyflie
@@ -209,6 +210,41 @@ class LogTest(unittest.TestCase):
 
         self.assertEqual(0, config.id)
         self.assertIn(config, self.log.log_blocks)
+
+    def test_delete_can_be_retried_when_sending_fails(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        config = self._make_config('config')
+        self.log.add_config(config)
+        self.cf.send_packet.reset_mock()
+        self.cf.send_packet.side_effect = [RuntimeError('send failed'), None]
+
+        with self.assertRaises(RuntimeError):
+            config.delete()
+        config.delete()
+
+        self.assertEqual(2, self.cf.send_packet.call_count)
+
+    def test_reset_can_be_retried_after_failed_acknowledgement(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING, error_status=errno.ENOEXEC)
+        self.cf.send_packet.reset_mock()
+
+        self.log.reset()
+
+        self.assertEqual(1, self.cf.send_packet.call_count)
+
+    def test_ids_are_unique_when_configs_are_registered_concurrently(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        configs = [self._make_config('config-{}'.format(i))
+                   for i in range(256)]
+
+        with ThreadPoolExecutor(max_workers=16) as executor:
+            list(executor.map(self.log.add_config, configs))
+
+        self.assertEqual(list(range(256)), sorted(
+            config.id for config in configs))
 
 
 if __name__ == '__main__':

--- a/test/crazyflie/test_log.py
+++ b/test/crazyflie/test_log.py
@@ -381,6 +381,35 @@ class LogTest(unittest.TestCase):
         self.assertFalse(disconnect_thread.is_alive())
         self.assertIsNone(config.id)
 
+    def test_synchronous_disconnect_during_start_does_not_deadlock(self):
+        self.log.reset()
+        self._acknowledge(CMD_RESET_LOGGING)
+        self.log.toc = MagicMock()
+        self.log.toc.get_element_by_complete_name.return_value = MagicMock()
+        self.log.toc.get_element_id.return_value = 1
+        config = LogConfig('config', 100)
+        config.add_variable('group.value', 'uint8_t')
+        self.log.add_config(config)
+        errors = []
+
+        def send_packet(packet, expected_reply):
+            self.cf.disconnected.call('radio://test')
+
+        def start():
+            try:
+                config.start()
+            except LogConfigError as error:
+                errors.append(error)
+
+        self.cf.send_packet.side_effect = send_packet
+        start_thread = threading.Thread(target=start, daemon=True)
+        start_thread.start()
+        start_thread.join(1.0)
+
+        self.assertFalse(start_thread.is_alive())
+        self.assertEqual(1, len(errors))
+        self.assertIsNone(config.id)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Abstract

Fix repeated `LogConfig` creation and deletion so applications can use logging for more than one byte-sized ID cycle without stale host-side blocks capturing reused IDs. Log block IDs are now managed as acknowledgement-owned leases, keeping host and firmware lifecycle state aligned across deletion, reset, disconnect, and concurrent commands.

Closes #577.

## Why

The previous implementation incremented an ID counter modulo 255 but never removed acknowledged-deleted configurations from `Log.log_blocks`. Once an ID wrapped, reply and log-data lookup found the stale configuration first. This made the firmware appear to run out of log blocks after repeated create/read/delete operations even though it had deleted them correctly.

The fix waits for the firmware deletion acknowledgement before releasing an ID. This is important because releasing earlier could route an in-flight reply or data packet to a newer configuration using the same opaque handle.

## What changed

- Manage the full firmware-supported `0..255` ID range with a thread-safe FIFO free-ID pool.
- Release and detach a configuration only after `DELETE` succeeds or returns `ENOENT`; failed deletion retains the lease and can be retried.
- Make delete idempotent while its acknowledgement is pending.
- Drain IDs on disconnect and reset, restoring the complete pool only after reset is acknowledged.
- Serialize log lifecycle commands and validate registration after packet sends so reset, delete, disconnect, and synchronous driver callbacks cannot create stale follow-up commands.
- Allow a detached `LogConfig` specification to be registered again with a fresh lease.
- Resolve variables without an explicit fetch type fresh on each registration, without accumulating duplicates.
- Raise `LogConfigError` for invalid lifecycle transitions while keeping detached cleanup calls harmless.

## Verification

- `uv run python -m unittest discover ./test` — 219 tests passed.
- Configured pre-commit hooks passed for both changed files and on every commit.
- Crazyflie over radio running the latest firmware:
  - 300 iterations using a newly constructed config each time passed.
  - 300 iterations re-registering one untyped config passed.
- Final independent standards and specification reviews reported clean.
